### PR TITLE
Scale EC2s at 75% capacity instead of 100%

### DIFF
--- a/infrastructure/terraform/cluster.tf
+++ b/infrastructure/terraform/cluster.tf
@@ -32,7 +32,13 @@ resource "aws_ecs_capacity_provider" "cluster_capacity" {
 
     managed_scaling {
       status          = "ENABLED"
-      target_capacity = 100
+
+      # Aim for 75% utilization of the autoscaling group
+      target_capacity = 75
+
+      # Scale by 2 EC2s or 10% of the group's max capacity, whichever is greater
+      minimum_scaling_step_size = max(2, ceil(0.10 * var.server-max-capacity))
+      maximum_scaling_step_size = var.server-max-capacity
     }
 
     # managed_termination_protection = "ENABLED"


### PR DESCRIPTION
This PR makes two autoscaling group changes:

1. We add additional servers at 75% capacity utilization instead of 100%, and
2. A minimum of two servers must be added to the cluster.

Load testing results indicated that the autoscaling group is a bottleneck under load - the capacity provider would only increment the number of required EC2s by one each time, effectively throttling the rate at which we can add tasks to the cluster. The first change means we initiate scaling sooner, and the second change ensures that we can add a larger number of tasks at one time.

**Deployment notes:** We may need to manually intervene in Terraform if it can't delete the current capacity provider.