### PR TITLE
[EPAD8-856] Display entity title or link text for link lists

### DIFF
--- a/services/drupal/config/sync/core.entity_view_display.paragraph.link_list.default.yml
+++ b/services/drupal/config/sync/core.entity_view_display.paragraph.link_list.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.paragraph.link_list.field_links
     - paragraphs.paragraphs_type.link_list
   module:
-    - link
+    - epa_links
 id: paragraph.link_list.default
 targetEntityType: paragraph
 bundle: link_list
@@ -16,13 +16,13 @@ content:
     weight: 2
     label: above
     settings:
-      trim_length: 80
+      trim_length: '80'
       url_only: false
       url_plain: false
-      rel: ''
-      target: ''
+      rel: 0
+      target: 0
     third_party_settings: {  }
-    type: link
+    type: epa_links_link_with_entity_title_or_link_text
     region: content
 hidden:
   search_api_excerpt: true

--- a/services/drupal/config/sync/core.extension.yml
+++ b/services/drupal/config/sync/core.extension.yml
@@ -51,6 +51,7 @@ module:
   epa_es_auth: 0
   epa_forms: 0
   epa_layouts: 0
+  epa_links: 0
   epa_media: 0
   epa_media_s3fs: 0
   epa_metatag: 0

--- a/services/drupal/web/modules/custom/epa_links/epa_links.info.yml
+++ b/services/drupal/web/modules/custom/epa_links/epa_links.info.yml
@@ -1,0 +1,7 @@
+name: 'EPA Links'
+description: Provides a custom link formatter for displaying links on EPA.gov.
+type: module
+core: 8.x
+package: EPA
+dependencies:
+  - drupal:link

--- a/services/drupal/web/modules/custom/epa_links/src/Plugin/Field/FieldFormatter/LinkWithEntityTitleOrLinkTextFormatter.php
+++ b/services/drupal/web/modules/custom/epa_links/src/Plugin/Field/FieldFormatter/LinkWithEntityTitleOrLinkTextFormatter.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Drupal\epa_links\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Drupal\link\LinkItemInterface;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'Link with entity title or link text' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "epa_links_link_with_entity_title_or_link_text",
+ *   label = @Translation("Link with entity title or link text"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class LinkWithEntityTitleOrLinkTextFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a LinkWithEntityTitleOrLinkTextFormatter instance.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings settings.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+    $entity = $items->getEntity();
+
+    foreach ($items as $delta => $item) {
+      // By default use the full URL as the link text.
+      $url = $this->buildUrl($item);
+      $link_title = $url->toString();
+
+      // If the url is internal, try to get the linked entity's title.
+      if ($url->isRouted()) {
+        $url_params = $url->getRouteParameters();
+        $entity_type = key($url_params);
+        $entity = $this->entityTypeManager->getStorage($entity_type)->load($url_params[$entity_type]);
+        $link_title = $entity->label();
+      }
+
+      // If the link text field value is available, use it for the text.
+      if (!empty($item->title)) {
+        // Unsanitized token replacement here because the entire link title
+        // gets auto-escaped during link generation in
+        // \Drupal\Core\Utility\LinkGenerator::generate().
+        // (Same logic as used by core's Link formatter).
+        $link_title = \Drupal::token()->replace($item->title, [$entity->getEntityTypeId() => $entity], ['clear' => TRUE]);
+      }
+
+      $element[$delta] = [
+        '#type' => 'link',
+        '#title' => $link_title,
+        '#options' => $url->getOptions(),
+      ];
+      $element[$delta]['#url'] = $url;
+
+    }
+    return $element;
+  }
+
+  /**
+   * Builds the \Drupal\Core\Url object for a link field item.
+   *
+   * @param \Drupal\link\LinkItemInterface $item
+   *   The link field item being rendered.
+   *
+   * @return \Drupal\Core\Url
+   *   A Url object.
+   */
+  protected function buildUrl(LinkItemInterface $item) {
+    $url = $item->getUrl() ?: Url::fromRoute('<none>');
+
+    $settings = $this->getSettings();
+    $options = $item->options;
+    $options += $url->getOptions();
+
+    // Add optional 'rel' attribute to link options.
+    if (!empty($settings['rel'])) {
+      $options['attributes']['rel'] = $settings['rel'];
+    }
+    // Add optional 'target' attribute to link options.
+    if (!empty($settings['target'])) {
+      $options['attributes']['target'] = $settings['target'];
+    }
+    $url->setOptions($options);
+
+    return $url;
+  }
+
+}

--- a/services/drupal/web/modules/custom/epa_links/src/Plugin/Field/FieldFormatter/LinkWithEntityTitleOrLinkTextFormatter.php
+++ b/services/drupal/web/modules/custom/epa_links/src/Plugin/Field/FieldFormatter/LinkWithEntityTitleOrLinkTextFormatter.php
@@ -90,7 +90,9 @@ class LinkWithEntityTitleOrLinkTextFormatter extends FormatterBase implements Co
         $url_params = $url->getRouteParameters();
         $entity_type = key($url_params);
         $entity = $this->entityTypeManager->getStorage($entity_type)->load($url_params[$entity_type]);
-        $link_title = $entity->label();
+        if ($entity && $entity->label()) {
+          $link_title = $entity->label();
+        }
       }
 
       // If the link text field value is available, use it for the text.

--- a/services/drupal/web/modules/custom/epa_links/src/Plugin/Field/FieldFormatter/LinkWithEntityTitleOrLinkTextFormatter.php
+++ b/services/drupal/web/modules/custom/epa_links/src/Plugin/Field/FieldFormatter/LinkWithEntityTitleOrLinkTextFormatter.php
@@ -96,30 +96,8 @@ class LinkWithEntityTitleOrLinkTextFormatter extends LinkFormatter {
       $url = $this->buildUrl($item);
       $link_title = $url->toString();
 
-      // If the title field value is available, use it for the link text.
-      if (empty($settings['url_only']) && !empty($item->title)) {
-        // Unsanitized token replacement here because the entire link title
-        // gets auto-escaped during link generation in
-        // \Drupal\Core\Utility\LinkGenerator::generate().
-        $link_title = \Drupal::token()->replace($item->title, [$entity->getEntityTypeId() => $entity], ['clear' => TRUE]);
-      }
-
-      $element[$delta] = [
-        '#type' => 'link',
-        '#title' => $link_title,
-        '#options' => $url->getOptions(),
-      ];
-      $element[$delta]['#url'] = $url;
-
-    }
-
-    foreach ($items as $delta => $item) {
-      // By default use the full URL as the link text.
-      $url = $this->buildUrl($item);
-      $link_title = $url->toString();
-
       // If the url is internal, try to get the linked entity's title.
-      if ($url->isRouted()) {
+      if (empty($settings['url_only']) && $url->isRouted()) {
         $url_params = $url->getRouteParameters();
         $entity_type = key($url_params);
         $entity = $this->entityTypeManager->getStorage($entity_type)->load($url_params[$entity_type]);


### PR DESCRIPTION
A new field formatter which extends `LinkFormatter` with the same options. When an internal entity is selected as the link and there is no text in the link text sub-field, the entity's label will be used as the link text. 