### PR TITLE
Create capacity providers before destroying

### DIFF
--- a/infrastructure/terraform/cluster.tf
+++ b/infrastructure/terraform/cluster.tf
@@ -48,6 +48,10 @@ resource "aws_ecs_capacity_provider" "cluster_capacity" {
     # Give this capacity provider a name that matches the random_pet to aid debugging/triage
     Name = "${local.name-prefix} ${random_pet.capacity_provider.id}"
   })
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # ECS cluster


### PR DESCRIPTION
By forcing Terraform to create a new capacity provider before destroying the old one, we should be able to avoid considerable downtime if/when we need to replace capacity providers in the future.