### PR TITLE
Print exit signal for debugging purposes

### DIFF
--- a/.buildkite/run-drush.sh
+++ b/.buildkite/run-drush.sh
@@ -148,6 +148,21 @@ while true; do
       echo "$exit_code"
     fi
 
+    # Did Drush exit due to a signal?
+    if test "$exit_code" -gt 128; then
+      # Find the signal number and try to match up a name if we can
+      signal=$((exit_code - 128))
+
+      echo -n "  WARNING: Drush exited with signal $signal"
+
+      # If the signal corresponded to a known signal name, print that out too
+      if signal_name="$(kill -l "$signal" 2>/dev/null)"; then
+        echo " ($signal_name)"
+      else
+        echo
+      fi
+    fi
+
     # Mark non-zero exits as a failure
     if test "$exit_code" -ne 0; then
       failure=1


### PR DESCRIPTION
In cases where Drush exits due to an external signal (SIGSEGV being the most recent example), the Buildkite script will now print the signal name so we know what happened.