### PR TITLE
Use least outstanding requests for load balancer strategy

### DIFF
--- a/infrastructure/terraform/alb.tf
+++ b/infrastructure/terraform/alb.tf
@@ -20,6 +20,8 @@ resource "aws_lb_target_group" "drupal_target_group" {
   target_type = "ip"
   vpc_id      = local.vpc-id
 
+  load_balancing_algorithm_type = "least_outstanding_requests"
+
   # Have the load balancer target the PHP-FPM status port (:8080) instead of the Drupal
   # application. In an ideal world, we could hit / to determine if Drupal is still
   # healthy, but this causes so much load on the PHP-FPM pool that it can cause the

--- a/infrastructure/terraform/providers.tf
+++ b/infrastructure/terraform/providers.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.49"
+  version = "~> 2.70"
   region  = var.aws-region
 }
 


### PR DESCRIPTION
During load testing, we saw that CPU load wasn't spread evenly across ECS tasks. This change requests that the load balancer distribute requests across tasks such that the task with the least amount of requests is prioritized, rather than the default (a round-robin strategy).