### PR TITLE
[EPAD8]  Create banner slides for nodes and node revisions separately

### DIFF
--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_revision_web_area_panelizer.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_revision_web_area_panelizer.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: _wkr24PlbbkzQAXqqA9Re0rWAaF35zXWPtrT-Jk8oiE
+  default_config_hash: yBzroRlIYYEpM_ElFmwiUE8gWbUNEaZRs0qv4RRVns8
 id: upgrade_d7_node_revision_web_area_panelizer
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null
@@ -194,6 +194,18 @@ process:
     -
       plugin: d7_metatag_entities
       source: pseudo_d7_metatag_entities
+  _banner_paragraphs:
+    plugin: migration_lookup
+    migration: upgrade_d7_node_revision_web_area_paragraph_banner
+    source: vid
+  field_banner:
+    -
+      plugin: sub_process
+      source:
+        - '@_banner_paragraphs'
+      process:
+        target_id: '0'
+        target_revision_id: '1'
 destination:
   plugin: 'entity_revision:node'
   default_bundle: web_area

--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_revision_web_area_paragraph_banner.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_revision_web_area_paragraph_banner.yml
@@ -1,8 +1,10 @@
-uuid: 95fa1f37-b0a4-4aaf-a456-e738c541ae34
+uuid: 40d22577-78ba-44c4-b9ab-00b748b8b292
 langcode: en
 status: true
 dependencies: {  }
-id: upgrade_d7_node_web_area_paragraph_banner
+_core:
+  default_config_hash: tSBunrb-fDsaF_ksrLAwJhgPk2haLDtBncOp57EFpgc
+id: upgrade_d7_node_revision_web_area_paragraph_banner
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null
 cck_plugin_method: null
@@ -10,12 +12,12 @@ migration_tags:
   - 'Drupal 7'
   - Content
 migration_group: migrate_drupal_7
-label: 'Paragraphs (Web Area, Banner)'
+label: 'Paragraphs (Web Area Revisions, Banner)'
 source:
-  plugin: d7_node
+  plugin: d7_node_revision
   node_type: web_area
   high_water_property:
-    name: nid
+    name: vid
     alias: nr
 process:
   _banner_slide_paragraphs:
@@ -27,8 +29,8 @@ process:
       plugin: sub_process
       source: '@_banner_slide_paragraphs'
       process:
-        target_id: 'destid1'
-        target_revision_id: 'destid2'
+        target_id: destid1
+        target_revision_id: destid2
 destination:
   plugin: 'entity_reference_revisions:paragraph'
   default_bundle: banner

--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_panelizer.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_panelizer.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: Pcr9Z3dAQyeRAmJbGliCH8vOA7YVsACPThJbH8XnNuo
+  default_config_hash: 6RG6dYlaweBOXlYXcpmLugC0yHQ-ac2QwOuE2FcGgS8
 id: upgrade_d7_node_web_area_panelizer
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null
@@ -195,7 +195,7 @@ process:
   _banner_paragraphs:
     plugin: migration_lookup
     migration: upgrade_d7_node_web_area_paragraph_banner
-    source: vid
+    source: nid
   field_banner:
     -
       plugin: sub_process

--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner.yml
@@ -1,9 +1,9 @@
-uuid: 40d22577-78ba-44c4-b9ab-00b748b8b292
+uuid: 95fa1f37-b0a4-4aaf-a456-e738c541ae34
 langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: RX59oIve4ttR_cJPSaiOm7F9J7JMiaMiSmLOkxI3WtE
+  default_config_hash: qiHtHaN6EHIVcNR-zu6K3wO6vK4xCYvtN7vsf5v-ens
 id: upgrade_d7_node_web_area_paragraph_banner
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null
@@ -14,10 +14,10 @@ migration_tags:
 migration_group: migrate_drupal_7
 label: 'Paragraphs (Web Area, Banner)'
 source:
-  plugin: d7_node_revision
+  plugin: d7_node
   node_type: web_area
   high_water_property:
-    name: vid
+    name: nid
     alias: nr
 process:
   _banner_slide_paragraphs:

--- a/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_revision_web_area_panelizer.yml
+++ b/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_revision_web_area_panelizer.yml
@@ -192,6 +192,18 @@ process:
     -
       plugin: d7_metatag_entities
       source: pseudo_d7_metatag_entities
+  _banner_paragraphs:
+    plugin: migration_lookup
+    migration: upgrade_d7_node_revision_web_area_paragraph_banner
+    source: vid
+  field_banner:
+    -
+      plugin: sub_process
+      source:
+        - '@_banner_paragraphs'
+      process:
+        target_id: '0'
+        target_revision_id: '1'
 destination:
   plugin: 'entity_revision:node'
   default_bundle: web_area

--- a/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_revision_web_area_paragraph_banner.yml
+++ b/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_revision_web_area_paragraph_banner.yml
@@ -1,8 +1,8 @@
-uuid: 95fa1f37-b0a4-4aaf-a456-e738c541ae34
+uuid: 40d22577-78ba-44c4-b9ab-00b748b8b292
 langcode: en
 status: true
 dependencies: {  }
-id: upgrade_d7_node_web_area_paragraph_banner
+id: upgrade_d7_node_revision_web_area_paragraph_banner
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null
 cck_plugin_method: null
@@ -10,12 +10,12 @@ migration_tags:
   - 'Drupal 7'
   - Content
 migration_group: migrate_drupal_7
-label: 'Paragraphs (Web Area, Banner)'
+label: 'Paragraphs (Web Area Revisions, Banner)'
 source:
-  plugin: d7_node
+  plugin: d7_node_revision
   node_type: web_area
   high_water_property:
-    name: nid
+    name: vid
     alias: nr
 process:
   _banner_slide_paragraphs:

--- a/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_web_area_panelizer.yml
+++ b/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_web_area_panelizer.yml
@@ -193,7 +193,7 @@ process:
   _banner_paragraphs:
     plugin: migration_lookup
     migration: upgrade_d7_node_web_area_paragraph_banner
-    source: vid
+    source: nid
   field_banner:
     -
       plugin: sub_process


### PR DESCRIPTION
I was using the 'node_revision' source plugin to create web area homepage banner paragraphs for all nodes. It turns out this source plugin excludes the current revision. To resolve, I added additional configuration to process homepage banner paragraphs separately for node (current revisions) and node revisions.