### PR TITLE
Allow load balancer to respond to other hostnames

### DIFF
--- a/infrastructure/terraform/alb.tf
+++ b/infrastructure/terraform/alb.tf
@@ -87,10 +87,7 @@ resource "aws_lb_listener_rule" "frontend_https" {
 
   condition {
     host_header {
-      # If the alb-hostname var isn't set, use the site hostname (this matters in cases
-      # where we're behind a CDN and the ALB's domain name is different from the
-      # public-facing domain name.)
-      values = [var.alb-hostname == null ? var.site-hostname : var.alb-hostname]
+      values = concat([var.site-hostname], var.alb-hostnames)
     }
   }
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -92,10 +92,10 @@ variable "alb-certificate" {
   type        = string
 }
 
-variable "alb-hostname" {
-  description = "Hostname for the ALB to listen to, in case it differs from the site-hostname variable."
-  type        = string
-  default     = null
+variable "alb-hostnames" {
+  description = "Additional hostnames for the load balancer to respond to in addition to the site-hostname variable"
+  type        = list(string)
+  default     = []
 }
 
 # Server-related variables


### PR DESCRIPTION
This PR changes the `alb-hostname` variable into an optional list of strings for other host names to match against incoming requests.