### PR TITLE
Epad8 730 paramaterize email further

### DIFF
--- a/infrastructure/terraform/cron.tf
+++ b/infrastructure/terraform/cron.tf
@@ -164,6 +164,7 @@ resource "aws_cloudwatch_event_target" "cron" {
         name = "drush"
         command = [
           "/var/www/html/vendor/bin/drush",
+          "--debug",
           "--uri", "https://${var.site-hostname}",
           "cron"
         ]

--- a/infrastructure/terraform/shared.tf
+++ b/infrastructure/terraform/shared.tf
@@ -24,6 +24,8 @@ locals {
     { name = "WEBCMS_MAIL_USER", value = var.email-auth-user },
     { name = "WEBCMS_MAIL_FROM", value = var.email-from },
     { name = "WEBCMS_MAIL_HOST", value = var.email-host },
+    { name = "WEBCMS_MAIL_PORT", value = var.email-port },
+    { name = "WEBCMS_MAIL_PROTOCOL", value = var.email-protocol },
 
     # Injected host names
     { name = "WEBCMS_SEARCH_HOST", value = "https://${aws_elasticsearch_domain.es.endpoint}:443" },

--- a/infrastructure/terraform/shared.tf
+++ b/infrastructure/terraform/shared.tf
@@ -26,6 +26,7 @@ locals {
     { name = "WEBCMS_MAIL_HOST", value = var.email-host },
     { name = "WEBCMS_MAIL_PORT", value = var.email-port },
     { name = "WEBCMS_MAIL_PROTOCOL", value = var.email-protocol },
+    { name = "WEBCMS_MAIL_ENABLE_WORKFLOW_NOTIFICATIONS", value = var.email-enable-workflow-notifications },
 
     # Injected host names
     { name = "WEBCMS_SEARCH_HOST", value = "https://${aws_elasticsearch_domain.es.endpoint}:443" },

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -271,6 +271,11 @@ variable "email-protocol" {
   type        = string
 }
 
+variable "email-enable-workflow-notifications" {
+  description = "Enable this to allow the system to email notifications to content editors about workflow state changes. This should only be enabled with care; we do not want a non-production environment mailing 'real' users notifications that they need to come review their content."
+  type        = bool
+}
+
 # Users
 # cf. iam.tf
 

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -261,6 +261,16 @@ variable "email-host" {
   type        = string
 }
 
+variable "email-port" {
+  description = "SMTP port to connect to"
+  type        = number
+}
+
+variable "email-protocol" {
+  description = "SMTP encryption protocol. Options are 'standard' for none, 'ssl', or 'tls'."
+  type        = string
+}
+
 # Users
 # cf. iam.tf
 

--- a/services/drupal/.env.example
+++ b/services/drupal/.env.example
@@ -26,6 +26,7 @@ WEBCMS_MAIL_FROM=noreply@epa.local
 WEBCMS_MAIL_HOST=mailhog
 WEBCMS_MAIL_PORT=1025
 WEBCMS_MAIL_PROTOCOL=standard
+WEBCMS_MAIL_ENABLE_WORKFLOW_NOTIFICATIONS=1
 
 # Set WEBCMS_ENV_NAME to a value like "local", "dev", "stage", or "prod".  This triggers the automatic inclusion of
 # settings.{WEBCMS_ENV_NAME}.env.php

--- a/services/drupal/.env.example
+++ b/services/drupal/.env.example
@@ -24,6 +24,8 @@ WEBCMS_MAIL_USER=bogus
 WEBCMS_MAIL_PASS=bogus
 WEBCMS_MAIL_FROM=noreply@epa.local
 WEBCMS_MAIL_HOST=mailhog
+WEBCMS_MAIL_PORT=1025
+WEBCMS_MAIL_PROTOCOL=standard
 
 # Set WEBCMS_ENV_NAME to a value like "local", "dev", "stage", or "prod".  This triggers the automatic inclusion of
 # settings.{WEBCMS_ENV_NAME}.env.php

--- a/services/drupal/web/modules/custom/epa_core/epa_core.services.yml
+++ b/services/drupal/web/modules/custom/epa_core/epa_core.services.yml
@@ -2,3 +2,7 @@ services:
   epa_core.helper:
     class: Drupal\epa_core\Utility\EpaCoreHelper
     arguments: ['@pathauto.alias_cleaner']
+  epa_core.overrider:
+    class: Drupal\epa_core\Config\EpaCoreOverrider
+    tags:
+      - { name: config.factory.override, priority: 5 }

--- a/services/drupal/web/modules/custom/epa_core/src/Config/EpaCoreOverrider.php
+++ b/services/drupal/web/modules/custom/epa_core/src/Config/EpaCoreOverrider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\epa_core\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Site\Settings;
+
+
+class EpaCoreOverrider implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    $notifications_enabled = Settings::get('epa_workflow_notifications_enabled', FALSE);
+    if (isset($names[0]) && strpos($names[0], 'content_moderation_notifications.content_moderation_notification.') === 0) {
+      foreach ($names as $name) {
+        $overrides[$name] = ['status' => $notifications_enabled];
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'EpaCoreOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+}

--- a/services/drupal/web/sites/default/settings.local.env.php
+++ b/services/drupal/web/sites/default/settings.local.env.php
@@ -1,6 +1,9 @@
 <?php
 
 // Override SMTP settings
+// These specific overrides are no longer necessary if you're using the latest
+// .env file but we'll leave them here to avoid breaking things for people who
+// haven't added the port and protocol entries to their .env files.
 $config['smtp.settings']['smtp_port'] = 1025;
 $config['smtp.settings']['smtp_protocol'] = 'standard';
 

--- a/services/drupal/web/sites/default/settings.php
+++ b/services/drupal/web/sites/default/settings.php
@@ -847,6 +847,7 @@ $config['smtp.settings']['smtp_from'] = getenv('WEBCMS_MAIL_FROM');
 $config['smtp.settings']['smtp_host'] = getenv('WEBCMS_MAIL_HOST');
 $config['smtp.settings']['smtp_port'] = getenv('WEBCMS_MAIL_PORT');
 $config['smtp.settings']['smtp_protocol'] = getenv('WEBCMS_MAIL_PROTOCOL');
+$settings['epa_workflow_notifications_enabled'] = (bool)getenv('WEBCMS_MAIL_ENABLE_WORKFLOW_NOTIFICATIONS');
 
 $config['samlauth.authentication']['sp_entity_id'] = getenv('WEBCMS_SAML_SP_ENTITY_ID');
 $config['samlauth.authentication']['sp_x509_certificate'] = getenv('WEBCMS_SAML_SP_CERT');

--- a/services/drupal/web/sites/default/settings.php
+++ b/services/drupal/web/sites/default/settings.php
@@ -845,6 +845,8 @@ $config['smtp.settings']['smtp_username'] = getenv('WEBCMS_MAIL_USER');
 $config['smtp.settings']['smtp_password'] = getenv('WEBCMS_MAIL_PASS');
 $config['smtp.settings']['smtp_from'] = getenv('WEBCMS_MAIL_FROM');
 $config['smtp.settings']['smtp_host'] = getenv('WEBCMS_MAIL_HOST');
+$config['smtp.settings']['smtp_port'] = getenv('WEBCMS_MAIL_PORT');
+$config['smtp.settings']['smtp_protocol'] = getenv('WEBCMS_MAIL_PROTOCOL');
 
 $config['samlauth.authentication']['sp_entity_id'] = getenv('WEBCMS_SAML_SP_ENTITY_ID');
 $config['samlauth.authentication']['sp_x509_certificate'] = getenv('WEBCMS_SAML_SP_CERT');


### PR DESCRIPTION
I'm parameterizing the port and protocol (Gopa asked for this).  I also provided a new setting to disable the sending of workflow notifications so that we could allow emailing to work in general without having to have all those emails get sent.  Please take a look and let me know what you think.

(And yes, the --debug flag for cron snuck in there but I'm not bothering to refactor).