### PR TITLE
EPAD8-933: Media embeds

### DIFF
--- a/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
+++ b/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
@@ -35,6 +35,13 @@ hero_slideshow:
   dependencies:
     - epa_theme/common
     - core/drupal
+media_link:
+  version: VERSION
+  js:
+    js/dist/media-link.min.js: {}
+  dependencies:
+    - epa_theme/common
+    - core/drupal
 svgxuse:
   version: 1.2.6
   js:

--- a/services/drupal/web/themes/epa_theme/js/src/media-link.es6.js
+++ b/services/drupal/web/themes/epa_theme/js/src/media-link.es6.js
@@ -1,0 +1,23 @@
+// Media embed with link
+import Drupal from 'drupal';
+
+(function(Drupal) {
+  Drupal.behaviors.mediaLink = {
+    attach(context) {
+      const mediaImages = context.querySelectorAll(
+        'a > .figure > .figure__media > img'
+      );
+
+      // Move anchors that wrap the figure to wrap the img instead.
+      mediaImages.forEach(mediaImage => {
+        const mediaObject = mediaImage.parentNode.parentNode.parentNode;
+        const mediaFigure = mediaObject.firstElementChild.cloneNode(true);
+        const mediaLink = mediaObject.cloneNode();
+
+        mediaLink.appendChild(mediaImage);
+        mediaFigure.firstElementChild.firstElementChild.replaceWith(mediaLink);
+        mediaObject.replaceWith(mediaFigure);
+      });
+    },
+  };
+})(Drupal);

--- a/services/drupal/web/themes/epa_theme/source/_meta/_01-foot.twig
+++ b/services/drupal/web/themes/epa_theme/source/_meta/_01-foot.twig
@@ -15,6 +15,7 @@
     <script src="../../../js/dist/scripts.min.js?{{ cacheBuster }}"></script>
     <script src="../../../js/dist/hero-slideshow.min.js?{{ cacheBuster }}"></script>
     <script src="../../../js/dist/image-gallery.min.js?{{ cacheBuster }}"></script>
+    <script src="../../../js/dist/media-link.min.js?{{ cacheBuster }}"></script>
     <script src="../../../js/dist/sitewide-alert.min.js?{{ cacheBuster }}"></script>
     <script src="../../../js/dist/toggle-admin.min.js?{{ cacheBuster }}"></script>
     <script src="../../../js/dist/definition.min.js?{{ cacheBuster }}"></script>

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/external-link--image/_external-link--image.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/external-link--image/_external-link--image.scss
@@ -1,18 +1,22 @@
 // @file
 // Styles for an External Image Link.
 
+%external-link--image-after {
+  background-color: rgba(255, 255, 255, 0.825);
+  background-position: center;
+  background-size: units('105');
+  margin: 0 !important;
+  padding: units('105');
+  position: absolute;
+  right: units('05');
+  top: units('05');
+}
+
 .external-link--image {
   display: inline-block;
   position: relative;
 
   &::after {
-    background-color: rgba(255, 255, 255, 0.825);
-    background-position: center;
-    background-size: units('105');
-    margin: 0 !important;
-    padding: units('105');
-    position: absolute;
-    right: units('05');
-    top: units('05');
+    @extend %external-link--image-after;
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/_figure.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/_figure.scss
@@ -23,6 +23,17 @@
 
   // Tweak styling in WYSIWYG editor.
   @if $wysiwyg {
+    // stylelint-disable
+    .cke_widget_wrapper:hover & {
+      outline: 2px solid #ffd25c;
+    }
+
+    .cke_widget_wrapper.cke_widget_focused &,
+    .cke_widget_wrapper.cke_widget_editable_focused & {
+      outline: 2px solid #47a4f5;
+    }
+    // stylelint-enable
+
     .media-library-item__edit {
       margin-bottom: rem(units(1));
     }
@@ -42,8 +53,12 @@
   font-size: font-size(body, 3xs);
   margin-top: rem(units(1));
 
-  // Show editable caption area in CKEditor when using Firefox.
-  &[contenteditable='true'] {
-    min-height: 1.3rem;
+  @if $wysiwyg {
+    // Show editable caption area in CKEditor when using Firefox.
+    &[contenteditable='true'] {
+      min-height: 1.3rem;
+      position: relative;
+      z-index: 1;
+    }
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/_figure.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/_figure.scss
@@ -45,6 +45,10 @@
   a:not([href=''], [href*='.gov'], [href^='#'], [href^='?'], [href^='/'], [href^='.'], [href^='javascript:'], [href^='mailto:'], [href*='webcms-uploads-dev.s3.amazonaws.com'], [href*='webcms-uploads-stage.s3.amazonaws.com'], [href*='webcms-uploads-prod.s3.amazonaws.com']) {
     @extend .external-link--image;
   }
+
+  a::after {
+    @extend %external-link--image-after;
+  }
 }
 
 .figure__caption {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/figure.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/figure.twig
@@ -1,3 +1,5 @@
+{{ attach_library('epa_theme/media_link') }}
+
 {% set classes = [
   'figure',
   modifier_classes ? modifier_classes,

--- a/services/drupal/web/themes/epa_theme/source/wysiwyg.scss
+++ b/services/drupal/web/themes/epa_theme/source/wysiwyg.scss
@@ -16,6 +16,10 @@ body.cke_editable {
   drupal-media {
     display: inline;
     outline: none !important;
+
+    > a::after {
+      display: none !important;
+    }
   }
 
   // stylelint-disable-next-line
@@ -25,5 +29,5 @@ body.cke_editable {
 }
 
 a[data-cke-saved-href]::after {
-  display: none;
+  display: none !important;
 }

--- a/services/drupal/web/themes/epa_theme/source/wysiwyg.scss
+++ b/services/drupal/web/themes/epa_theme/source/wysiwyg.scss
@@ -4,6 +4,26 @@ $wysiwyg: true;
 
 @import 'styles';
 
+// stylelint-disable-next-line
+body.cke_editable {
+  outline: none !important;
+}
+
+// stylelint-disable-next-line
+.cke_widget_drupalmedia {
+  display: inline;
+
+  drupal-media {
+    display: inline;
+    outline: none !important;
+  }
+
+  // stylelint-disable-next-line
+  .cke_widget_drag_handler_container {
+    display: none;
+  }
+}
+
 a[data-cke-saved-href]::after {
   display: none;
 }

--- a/services/drupal/web/themes/epa_theme/templates/media/media.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/media/media.html.twig
@@ -30,4 +30,3 @@
     'media': content,
   } %}
 {% endif %}
-


### PR DESCRIPTION
This PR will:
- Clean up WYSIWYG styles for the CKEditor focus outlines when applied to media embeds
- Add JS to move `<a>` that wraps figures to wrap the inner `<img>` instead
- Fix external image link styles when applied to figures