### PR TITLE
Enable extra performance data collection in Aurora MySQL

### DIFF
--- a/infrastructure/terraform/rds.tf
+++ b/infrastructure/terraform/rds.tf
@@ -26,6 +26,20 @@ resource "aws_rds_cluster_parameter_group" "params" {
     value = 64 * (1024 * 1024)
   }
 
+  # Slow query logging
+
+  # Enable the slow query log
+  parameter {
+    name  = "slow_query_log"
+    value = 1
+  }
+
+  # Log any queries that took longer than this many seconds
+  parameter {
+    name = "long_query_time"
+    value = 0.125
+  }
+
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} DB parameters"
   })

--- a/infrastructure/terraform/rds.tf
+++ b/infrastructure/terraform/rds.tf
@@ -36,7 +36,7 @@ resource "aws_rds_cluster_parameter_group" "params" {
 
   # Log any queries that took longer than this many seconds
   parameter {
-    name = "long_query_time"
+    name  = "long_query_time"
     value = 0.125
   }
 

--- a/infrastructure/terraform/rds.tf
+++ b/infrastructure/terraform/rds.tf
@@ -40,6 +40,20 @@ resource "aws_rds_cluster_parameter_group" "params" {
     value = 0.125
   }
 
+  # Log any queries not using indexes - if this is too much, we can throttle the amount of
+  # queries per minute that MySQL logs.
+  parameter {
+    name  = "log_queries_not_using_indexes"
+    value = 1
+  }
+
+  # Enable the performance schema - the defaults that ship with the MySQL server are more
+  # than likely enough for what we'll need.
+  parameter {
+    name  = "performance_schema"
+    value = 1
+  }
+
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} DB parameters"
   })


### PR DESCRIPTION
This PR adds extra collection from the MySQL server:

1. It enables the slow query log, which triggers on two conditions:
    1. Queries that take longer than 125ms. This is an extremely aggressive threshold that should be tuned lower once our migration testing is completed, but it will gives us more data in the meantime.
    2. Any query that does not use indexes. We are seeing MySQL perform joins that require full table scans, and logging this queries will allow us to tune anything causing trouble.
2. It enables MySQL's performance schema (see this [quick start](https://dev.mysql.com/doc/refman/5.7/en/performance-schema-quick-start.html)) to augment our usage of RDS performance insights.

**Deployment note**: Enabling these features requires a restart of the Aurora cluster instances. We will need to schedule a downtime window on environments where we want to make use of this feature (namely, staging). Other environments can let this apply during the next Aurora maintenance window.