### PR TITLE
Add styling to is-active main-menu link

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/menu/menu--main/_menu--main.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/menu/menu--main/_menu--main.scss
@@ -153,7 +153,8 @@
       }
 
       &:hover,
-      &:focus {
+      &:focus,
+      &.is-active {
         background: gesso-grayscale(gray-2);
         border-color: gesso-brand(blue, base);
         color: gesso-brand(blue, base);


### PR DESCRIPTION
@dcmouyard : we noticed that there was no indicator of the active page in the main menu