### PR TITLE
EPAD8-998: Enable ALB logs

### DIFF
--- a/infrastructure/terraform/alb.tf
+++ b/infrastructure/terraform/alb.tf
@@ -6,6 +6,11 @@ resource "aws_lb" "frontend" {
   security_groups    = [aws_security_group.load_balancer.id]
   subnets            = aws_subnet.public.*.id
 
+  access_logs {
+    bucket  = aws_s3_bucket.elb_logs.bucket
+    enabled = true
+  }
+
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} Load Balancer"
   })

--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -25,3 +25,27 @@ resource "aws_s3_bucket_policy" "uploads_policy" {
     ]
   })
 }
+
+# Create a random identifier for the logs bucket
+resource "random_id" "elb_logs_bucket" {
+  byte_length = 16
+  prefix      = "webcms-logs-${local.env-suffix}-"
+}
+
+resource "aws_s3_bucket" "elb_logs" {
+  bucket = random_id.elb_logs_bucket.b64_url
+
+  tags = merge(local.common-tags, {
+    Name = "${local.name-prefix} ELB Logs"
+  })
+}
+
+# Don't allow any public access to the ELB logging bucket
+resource "aws_s3_bucket_public_access_block" "elb_logs" {
+  bucket = aws_s3_bucket.elb_logs.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
This PR enables logging at the load balancer level. Logs are uploaded to S3 for offline ingestion, rather than in CloudWatch.