### PR TITLE
EPAD8-998: ELB logs

### DIFF
--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -29,11 +29,10 @@ resource "aws_s3_bucket_policy" "uploads_policy" {
 # Create a random identifier for the logs bucket
 resource "random_id" "elb_logs_bucket" {
   byte_length = 16
-  prefix      = "webcms-logs-${local.env-suffix}-"
 }
 
 resource "aws_s3_bucket" "elb_logs" {
-  bucket = random_id.elb_logs_bucket.b64_url
+  bucket = "webcms-logs-${random_id.elb_logs_bucket.b64_url}-${local.env-suffix}"
 
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} ELB Logs"

--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -26,13 +26,10 @@ resource "aws_s3_bucket_policy" "uploads_policy" {
   })
 }
 
-# Create a random identifier for the logs bucket
-resource "random_id" "elb_logs_bucket" {
-  byte_length = 16
-}
-
+# Create an S3 bucket using a random identifier (this is only used for administration so
+# the name doesn't have to be pretty)
 resource "aws_s3_bucket" "elb_logs" {
-  bucket = "webcms-logs-${random_id.elb_logs_bucket.b64_url}-${local.env-suffix}"
+  bucket_prefix = "webcms-logs-${local.env-suffix}-"
 
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} ELB Logs"


### PR DESCRIPTION
This PR ignores the initial attempts to use `random_id` and just generates a bucket using Terraform's prefix option.