### PR TITLE
EPAD8-998: Grant log delivery permission

### DIFF
--- a/infrastructure/terraform/alb.tf
+++ b/infrastructure/terraform/alb.tf
@@ -14,6 +14,9 @@ resource "aws_lb" "frontend" {
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} Load Balancer"
   })
+
+  # Explicitly depend on the S3 bucket policy that enables the ALB to deliver logs
+  depends_on = [aws_s3_bucket_policy.elb_logs_delivery]
 }
 
 # Target group for Drupal container tasks

--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -45,3 +45,68 @@ resource "aws_s3_bucket_public_access_block" "elb_logs" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Generate a bucket policy that grants access to the ELB logging bucket per
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+locals {
+  elb-accounts = {
+    "us-east-1"     = "127311923021"
+    "us-east-2"     = "033677994240"
+    "us-west-1"     = "027434742980"
+    "us-west-2"     = "797873946194"
+    "us-gov-west-1" = "048591011584"
+    "us-gov-east-1" = "190560391635"
+  }
+
+  elb-log-path = "arn:aws:s3:::${aws_s3_bucket.elb_logs.bucket}/AWSLogs/${data.aws_caller_identity.current.account_id}"
+}
+
+data "aws_iam_policy_document" "elb_logs_access" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "rootDelivery"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${local.elb-log-path}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam:${local.elb-accounts[var.aws-region]}:root"]
+    }
+  }
+
+  statement {
+    sid       = "elbDelivery"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${local.elb-log-path}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+
+  statement {
+    sid       = "aclAccess"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::${aws_s3_bucket.elb_logs.bucket}"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "elb_logs_delivery" {
+  bucket = aws_s3_bucket.elb_logs.bucket
+  policy = data.aws_iam_policy_document.elb_logs_access.json
+}

--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -97,6 +97,7 @@ data "aws_iam_policy_document" "elb_logs_access" {
   statement {
     sid       = "aclAccess"
     effect    = "Allow"
+    actions   = ["s3:GetBucketAcl"]
     resources = ["arn:aws:s3:::${aws_s3_bucket.elb_logs.bucket}"]
 
     principals {


### PR DESCRIPTION
Per the [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions), we need to explicitly grant the load balancing service permission to deliver logs to the logging bucket. This PR creates the necessary permission policy and applies it to the ELB logs bucket.