### PR TITLE
Make interface creation optional

### DIFF
--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -68,6 +68,12 @@ variable "vpc-existing-gateway" {
   default     = null
 }
 
+variable "vpc-create-interfaces" {
+  description = "Should endpoint interfaces be created for EC2 and SSM?"
+  type        = bool
+  default     = true
+}
+
 variable "vpc-subnet-block" {
   description = "CIDR block to use when allocating subnets. Defaults to using the full CIDR range of the VPC."
   type        = string

--- a/infrastructure/terraform/vpc.tf
+++ b/infrastructure/terraform/vpc.tf
@@ -204,7 +204,7 @@ resource "aws_vpc_endpoint" "s3" {
 
 locals {
   # Place Systems Manager endpoints into the VPC in order to further secure the connection
-  ssm-endpoints = ["ssm", "ec2", "ec2messages", "ssmmessages"]
+  ssm-endpoints = var.vpc-create-interfaces ? ["ssm", "ec2", "ec2messages", "ssmmessages"] : []
 }
 
 data "aws_vpc_endpoint_service" "ssm" {


### PR DESCRIPTION
In deployments using a shared VPC, we can't unconditionally create interface endpoints for SSM and EC2. There can only be one endpoint for a service in a VPC. This PR adds a variable, `vpc-create-interfaces`, to control the creation of the endpoint interfaces.

Initial testing has indicated that this does not apply to the S3 gateway (it uses a different mechanism that doesn't cause the overlap problem), so we can continue to create it in the VPC as normal.