### PR TITLE
[EPAD8-965] Check to make sure element to remove exists

### DIFF
--- a/services/drupal/web/modules/custom/epa_migrations/src/EpaWysiwygTextProcessingTrait.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/EpaWysiwygTextProcessingTrait.php
@@ -248,7 +248,7 @@ trait EpaWysiwygTextProcessingTrait {
       foreach ($page_top_links as $link) {
         // Delete the element and any parent elements that are now empty.
         $element_to_remove = $this->determineElementToRemove($link);
-        if ($element_to_remove) {
+        if ($element_to_remove->parentNode) {
           $element_to_remove->parentNode->removeChild($element_to_remove);
         }
       }
@@ -277,7 +277,7 @@ trait EpaWysiwygTextProcessingTrait {
       foreach ($exit_epa_links as $link) {
         // Delete the element and any parent elements that are now empty.
         $element_to_remove = $this->determineElementToRemove($link);
-        if ($element_to_remove) {
+        if ($element_to_remove->parentNode) {
           $element_to_remove->parentNode->removeChild($element_to_remove);
         }
       }
@@ -306,7 +306,7 @@ trait EpaWysiwygTextProcessingTrait {
       foreach ($pdf_disclaimer_elements as $element) {
         // Delete the element and any parent elements that are now empty.
         $element_to_remove = $this->determineElementToRemove($element);
-        if ($element_to_remove) {
+        if ($element_to_remove->parentNode) {
           $element_to_remove->parentNode->removeChild($element_to_remove);
         }
       }

--- a/services/drupal/web/modules/custom/epa_migrations/src/EpaWysiwygTextProcessingTrait.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/EpaWysiwygTextProcessingTrait.php
@@ -248,7 +248,9 @@ trait EpaWysiwygTextProcessingTrait {
       foreach ($page_top_links as $link) {
         // Delete the element and any parent elements that are now empty.
         $element_to_remove = $this->determineElementToRemove($link);
-        $element_to_remove->parentNode->removeChild($element_to_remove);
+        if ($element_to_remove) {
+          $element_to_remove->parentNode->removeChild($element_to_remove);
+        }
       }
     }
 
@@ -275,7 +277,9 @@ trait EpaWysiwygTextProcessingTrait {
       foreach ($exit_epa_links as $link) {
         // Delete the element and any parent elements that are now empty.
         $element_to_remove = $this->determineElementToRemove($link);
-        $element_to_remove->parentNode->removeChild($element_to_remove);
+        if ($element_to_remove) {
+          $element_to_remove->parentNode->removeChild($element_to_remove);
+        }
       }
     }
 
@@ -302,7 +306,9 @@ trait EpaWysiwygTextProcessingTrait {
       foreach ($pdf_disclaimer_elements as $element) {
         // Delete the element and any parent elements that are now empty.
         $element_to_remove = $this->determineElementToRemove($element);
-        $element_to_remove->parentNode->removeChild($element_to_remove);
+        if ($element_to_remove) {
+          $element_to_remove->parentNode->removeChild($element_to_remove);
+        }
       }
     }
 


### PR DESCRIPTION
Adding this check will hopefully avoid the 'element not found' error I saw during a test run of the basic page revision migration. I believe there's a possible case where we find an element to remove, but its parent ends up getting removed during the 'removeEmptyTextNodes' method.﻿
