### PR TITLE
Create block device mapping for utility instances

### DIFF
--- a/infrastructure/terraform/utility.tf
+++ b/infrastructure/terraform/utility.tf
@@ -140,6 +140,18 @@ resource "aws_launch_template" "utility" {
     name = aws_iam_instance_profile.utility_profile.name
   }
 
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      encrypted             = true
+      kms_key_id            = var.encryption-at-rest-key
+      volume_size           = 32
+      volume_type           = "gp2"
+      delete_on_termination = true
+    }
+  }
+
   tags = merge(local.common-tags, {
     Name = "${local.name-prefix} Utility"
   })


### PR DESCRIPTION
Add a block_device_mapping for the utility instances to provide a disk with 32GB of space. The default instance disk space is too small to hold a Stage database dump with migrated data.

Once this is merged and the build finishes, an SRE will need to terminate the existing utility instance so AWS will deploy a fresh one with the new block storage.