### PR TITLE
EPAD8-1016: Systems Manager automation documents

### DIFF
--- a/infrastructure/terraform/automation.tf
+++ b/infrastructure/terraform/automation.tf
@@ -1,0 +1,453 @@
+data "aws_iam_policy_document" "ssm_automation_assume_role_policy" {
+  version = "2012-10-17"
+
+  statement {
+    sid     = "1"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principal {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+  }
+}
+
+# Create a service role for Systems Manager. This role is used by AWS to interact with the
+# automation documents in this file, and is distinct from the role used by the automated
+# EC2 instances themselves.
+resource "aws_iam_role" "ssm_automation_role" {
+  name        = "${local.role-prefix}SSMAutomationRole"
+  description = "Role for Systems Manager to launch automation documents"
+
+  assume_role_policy = data.aws_iam_policy_document.ssm_automation_assume_role_policy.json
+
+  tags = local.common-tags
+}
+
+# Grant the automation role basic automation permissions
+resource "aws_iam_role_policy_attachment" "ssm_automation" {
+  role       = aws_iam_role.ssm_automation_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"
+}
+
+# Grant automation permission to provide the automated EC2 role to scripts
+data "aws_iam_policy_document" "ssm_automation_pass_role" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "passRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.ec2_automation_role.arn]
+  }
+}
+
+resource "aws_iam_policy" "ssm_automation_pass_role" {
+  name        = "${local.role-prefix}AutomationPassRole"
+  description = "Permits using the EC2 automation role"
+
+  policy = data.aws_iam_policy_document.ssm_automation_pass_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_automation_pass_role" {
+  role       = aws_iam_role.ssm_automation.name
+  policy_arn = aws_iam_policy.ssm_automation_pass_role.arn
+}
+
+data "aws_iam_policy_document" "ec2_automation_assume_role_policy" {
+  version = "2012-10-17"
+
+  statement {
+    sid     = "1"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principal {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# Create an automated instance role. This is the role that is attached to the automated
+# EC2 instances and thus needs permissions to interact with the backups bucket and DB
+# credentials.
+resource "aws_iam_role" "ec2_automation_role" {
+  name        = "${local.role-prefix}AutomatedInstanceRole"
+  description = "Role for automated EC2 instances"
+
+  assume_role_policy = data.aws_iam_policy_document.ec2_automation_assume_role_policy.json
+
+  tags = local.common-tags
+}
+
+# Grant automated EC2 instances permission to read from (and write to) the DB backups
+# S3 bucket.
+data "aws_iam_policy_document" "ec2_automation_s3_access" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "objectReadWrite"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["${aws_s3_bucket.backups.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "ec2_automation_s3_access" {
+  name        = "${local.role-prefix}AutomatedInstanceS3Access"
+  description = "Grants access to the DB backups S3 bucket"
+
+  policy = data.aws_iam_policy_document.ec2_automation_s3_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_automation_s3_access" {
+  role       = aws_iam_role.ec2_automation_role.name
+  policy_arn = aws_iam_policy.ec2_automation_s3_access.arn
+}
+
+# Grant automated EC2 instances permission to use the D8 and D7 database credentials
+data "aws_iam_policy_document" "ec2_automation_secrets_access" {
+  version = "2012-10-17"
+
+  statement {
+    sid     = "readCredentials"
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue"]
+
+    resources = [
+      aws_secretsmanager_secret.db_app_credentials.arn,
+      aws_secretsmanager_secret.db_app_d7_credentials.arn,
+    ]
+  }
+
+  statement {
+    sid       = "decryptSecret"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [data.aws_kms_alias.secretsmanager.target_key_arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["secretsmanager.${var.aws-region}.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "ec2_automation_secrets_access" {
+  name        = "${local.role-prefix}AutomatedInstanceSecretsAccess"
+  description = "Grants access to the D8 and D7 database credentials"
+
+  policy = data.aws_iam_policy_document.ec2_automation_secrets_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_automation_secrets_access" {
+  role       = aws_iam_role.ec2_automation_role.name
+  policy_arn = aws_iam_policy.ec2_automation_secrets_access.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_automation_managed_instance" {
+  role       = aws_iam_role.ec2_automation_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_automation_cloudwatch_agent" {
+  role       = aws_iam_role.ec2_automation_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "ec2_automation_profile" {
+  name = "${local.role-prefix}AutomatedInstanceProfile"
+  role = aws_iam_role.ec2_automation_role.name
+}
+
+# Elements shared across all SSM documents. Since our documents share the same general
+# structure (launch instance, run script, terminate instance), we avoid repetition and
+# potential configuration drift by storing the shared steps here.
+locals {
+  # Step 1. Spawn a new EC2 instance using our automated instance profile.
+  ssm-run-instance = {
+    name   = "runInstance"
+    action = "aws:RunInstances"
+
+    inputs = {
+      # Start a relatively small EC2 instance running stock Amazon Linux 2.
+      ImageId                = "{{ InstanceAMI }}"
+      SubnetId               = aws_subnet.private[0].id
+      InstanceType           = "t3a.small"
+      IamInstanceProfileName = aws_iam_instance_profile.ec2_automation_profile.name
+
+      # Use the same security group settings as the utility instance; we need to access
+      # S3 and the RDS proxy but nothing else in the VPC.
+      SecurityGroupIds = [
+        aws_security_group.utility.id,
+        aws_security_group.proxy_access.id,
+      ]
+
+      # Use a large ephemeral volume due to the large size of uncompressed DB dumps.
+      BlockDeviceMappings = [
+        {
+          DeviceName = "/dev/xvda"
+          Ebs = {
+            DeleteOnTermination = true
+            VolumeSize          = 64
+          }
+        }
+      ]
+    }
+  }
+
+  # Step 2. Ensure the instance is ready and connected to Systems Manager.
+  ssm-instance-warmup = {
+    name   = "instanceWarmUp"
+    action = "aws:waitForAwsResourceProperty"
+
+    # Wait for an hour, up to three times, before giving up
+    timeoutSeconds = 600
+    maxAttempts    = 3
+
+    # If the warmup fails, terminate the instance
+    onFailure = "step:terminateInstance"
+
+    inputs = {
+      Service          = "ec2"
+      Api              = "DescribeInstanceStatus"
+      PropertySelector = "$.InstanceStatuses[0].InstanceStatus.Details[0].Status"
+      DesiredValues    = ["passed"]
+      InstanceIds      = ["{{ runInstances.InstanceIds }}"]
+    }
+  }
+
+  # Step 4. Terminate the instance. All steps beyond the first should route to here on
+  # failure in order to prevent accruing costs for a stray EC2 instance. (Step 3, the SSM
+  # command, is omitted here since it varies between automation documents.)
+  ssm-cleanup = {
+    name   = "terminateInstance"
+    action = "aws:changeInstanceState"
+    isEnd  = true
+
+    inputs = {
+      DesiredState = "terminated"
+      InstanceIds  = "{{ runInstance.InstanceIds }}"
+    }
+  }
+}
+
+# Create an automation document that loads a D7 backup from the backups bucket into the
+# database.
+resource "aws_ssm_document" "d7_load_database" {
+  name          = "WebCMS-${local.env-title}-D7LoadDatabase"
+  document_type = "Automation"
+
+  content = jsonencode({
+    schemaVersion = "0.3"
+    description   = <<-EOF
+      # Load D7 Database Automation
+
+      This automation loads a copy of the latest D7 database dump into the `webcms_d7` DB.
+      The dump must be present in the DB backups bucket (`s3://${aws_s3_bucket.backups.bucket}`)
+      and be saved as a gzip-compressed `.sql` file.
+
+      ## Parameters
+
+      * `BackupName` - the path to the database dump in S3.
+      * `InstanceAMI` - this parameter exists due to a limitation in Systems Manager. Leave
+        it blank in order to use the latest Amazon Linux 2 image when automation runs.
+    EOF
+
+    # Run this document as our SSM service role
+    assumeRole = aws_iam_role.ssm_automation_role.arn
+
+    parameters = {
+      BackupName = {
+        type        = "String"
+        description = "Name of the DB in the backups bucket (s3://${aws_s3_bucket.backups.bucket})"
+      }
+
+      # Systems Manager won't let us directly reference the AMI parameter in our document,
+      # so we have to use this default value to have SSM read it.
+      InstanceAMI = {
+        type        = "String"
+        description = "Amazon Linux 2 AMI to run on the instance. Defaults to the latest."
+        default     = "{{ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      }
+    }
+
+    mainSteps = [
+      # Use the shared steps to spawn the instance
+      local.ssm-run-instance,
+      local.ssm-instance-warmup,
+
+      # Run our import script on the instance
+      {
+        name   = "runImportScript"
+        action = "aws:runCommand"
+
+        # Wait up to 8 hours
+        timeoutSeconds = 8 * 60 * 60
+
+        # Terminate the instance on failure
+        onFailure = "step:terminateInstance"
+
+        inputs = {
+          DocumentName = "AWS-RunShellScript"
+          InstanceIds  = "{{ runInstance.InstanceIds }}"
+
+          # Send automation logs to CloudWatch
+          CloudWatchOutputConfig = {
+            CloudWatchLogGroupName  = aws_cloudwatch_log_group.ssm_d7_automation.name
+            CloudWatchOutputEnabled = true
+          }
+
+          # Script steps:
+          # 1. Install necessary CLI tools
+          # 2. Download the backup from S3 and decompress it
+          # 3. Obtain the D7 login credentials
+          # 4. Load the dump into MySQL through the RDS proxy
+          Parameters = {
+            executionTimeOut = tostring(8 * 60 * 60)
+            workingDirectory = "/tmp"
+            commands         = <<-EOF
+              set -euo pipefail
+
+              yum install -y awscli jq mariadb
+
+              echo "Downloading {{ BackupName }} from S3"
+
+              aws s3 cp s3://${aws_s3_bucket.backups.bucket}/{{ BackupName }} ./d7.sql.gz
+              gunzip ./d7.sql.gz
+
+              credentials="$(
+                aws --region=${var.aws-region} \
+                secretsmanager get-secret-value \
+                  --secret-id ${aws_secretsmanager_secret.db_app_d7_credentials.id} |
+                  jq -r .SecretString
+              )"
+
+              username="$(jq -r .username <<<"$credentials")"
+              password="$(jq -r .password <<<"$credentials")"
+
+              echo "Loading {{ BackupName }} into MySQL"
+
+              mysql \
+                --host=${aws_db_proxy.proxy.endpoint} \
+                --user="$username" \
+                --password="$password" \
+                webcms_d7 \
+                <./d7.sql
+            EOF
+          }
+        }
+      },
+
+      # Clean up the instance
+      local.ssm-cleanup
+    ]
+  })
+
+  tags = local.common-tags
+}
+
+resource "aws_ssm_document" "d8_dump_database" {
+  name          = "WebCMS-${local.env-title}-D8DumpDatabase"
+  document_type = "Automation"
+
+  content = jsonencode({
+    schemaVersion = "0.3"
+    description   = <<-EOF
+      # Dump D8 Database Automation
+
+      This automation dumps the D8 database and saves it into the DB backups bucket
+      (`s3://${aws_s3_bucket.backups.bucket}`) as `webcms-YYYY-MM-DD-HHMM.sql.gz`.
+
+      ## Parameters
+      * `InstanceAMI` - this parameter exists due to a limitation in Systems Manager. Leave
+        it blank in order to use the latest Amazon Linux 2 image when automation runs.
+    EOF
+
+    assumeRole = aws_iam_role.ssm_automation_role.arn
+
+    parameters = {
+      # See comments in the D7 automation for why this exists
+      InstanceAMI = {
+        type        = "String"
+        description = "Amazon Linux 2 AMI to run on the instance. Defaults to the latest."
+        default     = "{{ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2}}"
+      }
+    }
+
+    mainSteps = [
+      # Spawn the instance
+      local.ssm-run-instance,
+      local.ssm-instance-warmup,
+
+      # Create and upload the DB dump
+      {
+        name   = "runExportScript"
+        action = "aws:runCommand"
+
+        timeoutSeconds = 8 * 60 * 60
+        onFailure      = "step:TerminateInstance"
+
+        inputs = {
+          DocumentName = "AWS-RunShellScript"
+          InstanceIds  = "{{ runInstance.InstanceIds }}"
+
+          CloudWatchOutputConfig = {
+            CloudWatchLogGroupName  = aws_cloudwatch_log_group.ssm_d8_automation.name
+            CloudWatchOutputEnabled = true
+          }
+
+          # Script steps:
+          # 1. Install necessary CLI tools
+          # 2. Obtain D8 DB credentials
+          # 3. Dump the database
+          # 4. Compress the database
+          # 5. Upload the compressed file to S3
+          Parameters = {
+            executionTimeOut = tostring(8 * 60 * 60)
+            workingDirectory = "/tmp"
+            commands         = <<-EOF
+              set -euo pipefail
+
+              yum install -y awscli jq mariadb
+
+              credentials="$(
+                aws --region=${var.aws-region} \
+                secretsmanager get-secret-value \
+                  --secret-id ${aws_secretsmanager_secret.db_app_credentials.id} |
+                  jq -r .SecretString
+              )"
+
+              username="$(jq -r .username <<<"$credentials")"
+              password="$(jq -r .password <<<"$credentials")"
+
+              dump_name="webcms-$(date +%Y-%m-%d-%H%M).sql"
+              archive_name="$dump_name.gz"
+
+              echo "Dumping database as $dump_name"
+
+              mysqldump \
+                --host=${aws_db_proxy.proxy.endpoint} \
+                --user="$username" \
+                --password="$password" \
+                webcms \
+                >"$dump_name"
+
+              echo "Compressing $dump_name to $archive_name"
+              gzip --verbose "$dump_name"
+
+              echo "Uploading $archive_name"
+              aws s3 cp "$archive_name" "s3://${aws_s3_bucket.backups.bucket}/$archive_name"
+            EOF
+          }
+        }
+      },
+
+      # Clean up the instance
+      local.ssm-cleanup
+    ]
+  })
+}

--- a/infrastructure/terraform/automation.tf
+++ b/infrastructure/terraform/automation.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "ssm_automation_assume_role_policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principal {
+    principals {
       type        = "Service"
       identifiers = ["ssm.amazonaws.com"]
     }
@@ -51,7 +51,7 @@ resource "aws_iam_policy" "ssm_automation_pass_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_automation_pass_role" {
-  role       = aws_iam_role.ssm_automation.name
+  role       = aws_iam_role.ssm_automation_role.name
   policy_arn = aws_iam_policy.ssm_automation_pass_role.arn
 }
 
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "ec2_automation_assume_role_policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principal {
+    principals {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
     }

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -672,8 +672,8 @@ resource "aws_iam_policy" "user_run_tasks_policy" {
   policy      = data.aws_iam_policy_document.user_run_tasks_policy[0].json
 }
 
-# Grants read access to the uploads bucket as well as read/write access to the objects in
-# it.
+# Grants read access to the both the uploads and backups buckets, as well as read/write
+# access to the objects in them.
 data "aws_iam_policy_document" "user_s3_access_policy" {
   version = "2012-10-17"
 
@@ -692,7 +692,7 @@ data "aws_iam_policy_document" "user_s3_access_policy" {
 
     effect    = "Allow"
     actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.uploads.arn]
+    resources = [aws_s3_bucket.uploads.arn, aws_s3_bucket.backups.arn]
   }
 
   statement {
@@ -700,14 +700,79 @@ data "aws_iam_policy_document" "user_s3_access_policy" {
 
     effect    = "Allow"
     actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-    resources = ["${aws_s3_bucket.uploads.arn}/*"]
+    resources = ["${aws_s3_bucket.uploads.arn}/*", "${aws_s3_bucket.backups.arn}/*"]
   }
 }
 
 resource "aws_iam_policy" "user_s3_access_policy" {
   name        = "${local.role-prefix}UserS3AccessPolicy"
-  description = "Grants access to the uploads S3 bucket"
+  description = "Grants access to the uploads and backups buckets"
   policy      = data.aws_iam_policy_document.user_s3_access_policy.json
+}
+
+# Grants WebCMS administrators access to the Systems Manager automation documents to
+# manage the database (see automation.tf).
+data "aws_iam_policy_document" "user_automation_policy" {
+  version = "2012-10-17"
+
+  # To determine: can these automation execution-related permissions be further limited in scope?
+  statement {
+    sid       = "viewExecutions"
+    effect    = "Allow"
+
+    actions = [
+      "ssm:DescribeAutomationExecutions",
+      "ssm:GetAutomationExecution",
+      "ssm:DescribeAutomationStepExecutions",
+      "ssm:ListCommands",
+      "ssm:StopAutomationExecution",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:*"
+    ]
+  }
+
+  statement {
+    sid = "listDocuments"
+    effect = "Allow"
+    actions = ["ssm:ListDocuments"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "viewDocuments"
+    effect = "Allow"
+
+    actions = [
+      "ssm:DescribeDocument",
+      "ssm:DescribeDocumentParameters",
+      "ssm:GetDocument",
+      "ssm:DescribeDocumentPermission",
+    ]
+
+    resources = [
+      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:document/${aws_ssm_document.d7_load_database.name}",
+      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:document/${aws_ssm_document.d8_dump_database.name}",
+    ]
+  }
+
+  statement {
+    sid = "executeDocuments"
+    effect = "Allow"
+    actions = ["ssm:StartAutomationExecution"]
+
+    resources = [
+      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:automation-definition/${aws_ssm_document.d7_load_database.name}:*",
+      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:automation-definition/${aws_ssm_document.d8_dump_database.name}:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "user_automation_policy" {
+  name = "${local.role-prefix}UserAutomationExecutionPolicy"
+  description = "Grants permission to view and run automation documents that load and restore MySQL database dumps."
+policy = data.aws_iam_policy_document.user_automation_policy.json
 }
 
 resource "aws_iam_group" "webcms_administrators" {
@@ -742,6 +807,11 @@ resource "aws_iam_group_policy_attachment" "webcms_administrators_secrets_access
 resource "aws_iam_group_policy_attachment" "webcm_administrators_s3_access" {
   group      = aws_iam_group.webcms_administrators.name
   policy_arn = aws_iam_policy.user_s3_access_policy.arn
+}
+
+resource "aws_iam_group_policy_attachment" "webcms_administrators_automation_access" {
+  group = aws_iam_group.webcms_administrators.name
+  policy_arn = aws_iam_policy.user_automation_policy.arn
 }
 
 resource "aws_iam_group_policy_attachment" "webcm_administrators_run_tasks" {

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -717,8 +717,8 @@ data "aws_iam_policy_document" "user_automation_policy" {
 
   # To determine: can these automation execution-related permissions be further limited in scope?
   statement {
-    sid       = "viewExecutions"
-    effect    = "Allow"
+    sid    = "viewExecutions"
+    effect = "Allow"
 
     actions = [
       "ssm:DescribeAutomationExecutions",
@@ -734,9 +734,9 @@ data "aws_iam_policy_document" "user_automation_policy" {
   }
 
   statement {
-    sid = "listDocuments"
-    effect = "Allow"
-    actions = ["ssm:ListDocuments"]
+    sid       = "listDocuments"
+    effect    = "Allow"
+    actions   = ["ssm:ListDocuments"]
     resources = ["*"]
   }
 
@@ -758,8 +758,8 @@ data "aws_iam_policy_document" "user_automation_policy" {
   }
 
   statement {
-    sid = "executeDocuments"
-    effect = "Allow"
+    sid     = "executeDocuments"
+    effect  = "Allow"
     actions = ["ssm:StartAutomationExecution"]
 
     resources = [
@@ -770,9 +770,9 @@ data "aws_iam_policy_document" "user_automation_policy" {
 }
 
 resource "aws_iam_policy" "user_automation_policy" {
-  name = "${local.role-prefix}UserAutomationExecutionPolicy"
+  name        = "${local.role-prefix}UserAutomationExecutionPolicy"
   description = "Grants permission to view and run automation documents that load and restore MySQL database dumps."
-policy = data.aws_iam_policy_document.user_automation_policy.json
+  policy      = data.aws_iam_policy_document.user_automation_policy.json
 }
 
 resource "aws_iam_group" "webcms_administrators" {
@@ -810,7 +810,7 @@ resource "aws_iam_group_policy_attachment" "webcm_administrators_s3_access" {
 }
 
 resource "aws_iam_group_policy_attachment" "webcms_administrators_automation_access" {
-  group = aws_iam_group.webcms_administrators.name
+  group      = aws_iam_group.webcms_administrators.name
   policy_arn = aws_iam_policy.user_automation_policy.arn
 }
 

--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -729,7 +729,7 @@ data "aws_iam_policy_document" "user_automation_policy" {
     ]
 
     resources = [
-      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:*"
+      "arn:aws:ssm:${var.aws-region}:${data.aws_caller_identity.current.account_id}:*"
     ]
   }
 
@@ -752,8 +752,8 @@ data "aws_iam_policy_document" "user_automation_policy" {
     ]
 
     resources = [
-      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:document/${aws_ssm_document.d7_load_database.name}",
-      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:document/${aws_ssm_document.d8_dump_database.name}",
+      "arn:aws:ssm:${var.aws-region}:${data.aws_caller_identity.current.account_id}:document/${aws_ssm_document.d7_load_database.name}",
+      "arn:aws:ssm:${var.aws-region}:${data.aws_caller_identity.current.account_id}:document/${aws_ssm_document.d8_dump_database.name}",
     ]
   }
 
@@ -763,8 +763,8 @@ data "aws_iam_policy_document" "user_automation_policy" {
     actions = ["ssm:StartAutomationExecution"]
 
     resources = [
-      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:automation-definition/${aws_ssm_document.d7_load_database.name}:*",
-      "arn:aws:ssm:${var.aws-region}:${data.aws_account_id.current.id}:automation-definition/${aws_ssm_document.d8_dump_database.name}:*",
+      "arn:aws:ssm:${var.aws-region}:${data.aws_caller_identity.current.account_id}:automation-definition/${aws_ssm_document.d7_load_database.name}:*",
+      "arn:aws:ssm:${var.aws-region}:${data.aws_caller_identity.current.account_id}:automation-definition/${aws_ssm_document.d8_dump_database.name}:*",
     ]
   }
 }

--- a/infrastructure/terraform/logging.tf
+++ b/infrastructure/terraform/logging.tf
@@ -22,3 +22,13 @@ resource "aws_cloudwatch_log_group" "agent" {
 resource "aws_cloudwatch_log_group" "fpm_metrics" {
   name = "/webcms-${local.env-suffix}/fpm-metrics"
 }
+
+# Log group for SSM automation for the D7 DB
+resource "aws_cloudwatch_log_group" "ssm_d7_automation" {
+  name = "/webcms-${local.env-suffix}/d7-automation"
+}
+
+# Log group for SSM automation for the D8 DB
+resource "aws_cloudwatch_log_group" "ssm_d8_automation" {
+  name = "/webcms-${local.env-suffix}/d8-automation"
+}

--- a/infrastructure/terraform/proxy.tf
+++ b/infrastructure/terraform/proxy.tf
@@ -21,10 +21,6 @@ resource "aws_iam_role" "proxy" {
   tags = local.common-tags
 }
 
-data "aws_kms_alias" "secretsmanager" {
-  name = "alias/aws/secretsmanager"
-}
-
 data "aws_iam_policy_document" "proxy_secrets" {
   version = "2012-10-17"
 

--- a/infrastructure/terraform/s3.tf
+++ b/infrastructure/terraform/s3.tf
@@ -111,3 +111,23 @@ resource "aws_s3_bucket_policy" "elb_logs_delivery" {
   bucket = aws_s3_bucket.elb_logs.bucket
   policy = data.aws_iam_policy_document.elb_logs_access.json
 }
+
+# Create a bucket to house DB backups
+resource "aws_s3_bucket" "backups" {
+  bucket_prefix = "webcms-db-backups-${local.env-suffix}-"
+
+  tags = merge(local.common-tags, {
+    Name = "${local.name-prefix} DB Backups"
+  })
+}
+
+# As with the ELB logs bucket, this bucket is fully private. No public access should be
+# permitted.
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket = aws_s3_bucket.backups.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/infrastructure/terraform/shared.tf
+++ b/infrastructure/terraform/shared.tf
@@ -3,6 +3,10 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+data "aws_kms_alias" "secretsmanager" {
+  name = "alias/aws/secretsmanager"
+}
+
 # We use separate definitions for the web-facing Drupal tasks and scheduled Drush cron
 # scripts for a few reasons (such as avoiding spawning nginx), so we share the values
 # here.


### PR DESCRIPTION
This PR creates a pair of Systems Manager automation documents to interact with the database. Normally, these would be handled as ECS tasks, but there are a few limitations that we've run into:
1. `drush sqlc` imposes a timeout, and loading database dumps of this magnitude trip that limit; and
2. The database dumps themselves are large enough that they will exhaust Fargate task storage (this will be improved in 1.4.0, but we may still need to be wary).

With these factors in mind, we are using SSM automation to spawn temporary EC2 instances with a large enough root volume to handle both compressed and uncompressed database dumps. Decompressed, these dumps can be over 12GiB in size.

The general structure of both automation documents is as follows:
1. Spawn an EC2 instance in the cluster's VPC.
2. Wait for the instance to fully boot.
3. Run the script (either loading the D7 database or dumping the D8 one).
4. Terminate the instance.

Permission is granted to the WebCMS administrators group to run these two documents.