### PR TITLE
EPAD8-1016: Automation fixes

### DIFF
--- a/infrastructure/terraform/automation.tf
+++ b/infrastructure/terraform/automation.tf
@@ -179,11 +179,12 @@ locals {
       InstanceType           = "t3a.small"
       IamInstanceProfileName = aws_iam_instance_profile.ec2_automation_profile.name
 
-      # Use the same security group settings as the utility instance; we need to access
-      # S3 and the RDS proxy but nothing else in the VPC.
+      # Use the automated server security group and also grant access to the RDS proxy
+      # and VPC interfaces.
       SecurityGroupIds = [
-        aws_security_group.utility.id,
+        aws_security_group.automation.id,
         aws_security_group.proxy_access.id,
+        aws_security_group.interface_access.id,
       ]
 
       # Use a large ephemeral volume due to the large size of uncompressed DB dumps.

--- a/infrastructure/terraform/automation.tf
+++ b/infrastructure/terraform/automation.tf
@@ -307,7 +307,7 @@ resource "aws_ssm_document" "d7_load_database" {
           # 3. Obtain the D7 login credentials
           # 4. Load the dump into MySQL through the RDS proxy
           Parameters = {
-            executionTimeOut = tostring(8 * 60 * 60)
+            executionTimeout = tostring(8 * 60 * 60)
             workingDirectory = "/tmp"
             commands         = <<-EOF
               set -euo pipefail
@@ -407,7 +407,7 @@ resource "aws_ssm_document" "d8_dump_database" {
           # 4. Compress the database
           # 5. Upload the compressed file to S3
           Parameters = {
-            executionTimeOut = tostring(8 * 60 * 60)
+            executionTimeout = tostring(8 * 60 * 60)
             workingDirectory = "/tmp"
             commands         = <<-EOF
               set -euo pipefail

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -570,6 +570,8 @@ resource "aws_security_group_rule" "search_access_ingress" {
   source_security_group_id = aws_security_group.search_access.id
 }
 
+# Security group for automated EC2 instances. They need arbitrary outbound HTTP in order
+# to be able to access AWS APIs that we have not yet provided VPC interfaces for.
 resource "aws_security_group" "automation" {
   name        = "webcms-automation-${local.env-suffix}"
   description = "Security group for automated EC2 instances"

--- a/infrastructure/terraform/security.tf
+++ b/infrastructure/terraform/security.tf
@@ -569,3 +569,32 @@ resource "aws_security_group_rule" "search_access_ingress" {
 
   source_security_group_id = aws_security_group.search_access.id
 }
+
+resource "aws_security_group" "automation" {
+  name        = "webcms-automation-${local.env-suffix}"
+  description = "Security group for automated EC2 instances"
+
+  vpc_id = local.vpc-id
+
+  egress {
+    description = "Allow outbound HTTP"
+
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow outbound HTTPS"
+
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common-tags, {
+    Name = "${local.name-prefix} Automated Instances"
+  })
+}


### PR DESCRIPTION
This fixes two bugs in the automation documents:

1. Incorrect capitalization of `executionTimeout`, and
2. The automated instances were not able to access AWS Secrets Manager and thus would wait almost indefinitely for a connection that could never complete.