### PR TITLE
[EPAD8-1021] Don't use heuristic to find group menu names

### DIFF
--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaOgMenuLink.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaOgMenuLink.php
@@ -26,7 +26,8 @@ class EpaOgMenuLink extends MenuLink {
   public function query() {
     $query = parent::query();
 
-    $query->condition('ml.menu_name', 'menu-og-%', 'LIKE');
+    $query->leftJoin('og_menu', 'om', 'ml.menu_name = om.menu_name');
+    $query->condition('om.menu_name', NULL, 'IS NOT NULL');
 
     return $query;
   }


### PR DESCRIPTION
This raises migration count from 4388 to 4477, as expected.