### PR TITLE
Catch ECS RunTask errors during Drush updates

### DIFF
--- a/.buildkite/run-drush.sh
+++ b/.buildkite/run-drush.sh
@@ -51,7 +51,7 @@ aws ecs list-tasks --cluster "$cluster" --family "webcms-drupal-$WEBCMS_ENVIRONM
   # xargs to use up to two child processes at once. This lets us parallelize the otherwise
   # sequential job of stopping ECS tasks. (The task ARN is prepended by xargs, so we don't
   # need to specify a template string.)
-  xargs -L1 -P2 aws ecs stop-task --cluster "$cluster" --task
+  xargs -L1 -P2 aws ecs stop-task --cluster "$cluster" --query 'task.taskArn' --task
 
 echo "--- Running Drush"
 

--- a/.buildkite/run-drush.sh
+++ b/.buildkite/run-drush.sh
@@ -42,16 +42,21 @@ network_configuration="$(cat drushvpc.json)"
 echo "--- Stopping Drupal Tasks"
 
 # The list-tasks command produces a JSON object like {taskArns: ["task", "task"]}, but the
-# stop-task API only accepts one task. This pipeline uses jq to make the returned JSON
-# more amenable to xargs, and xargs to stop tasks in parallel.
-aws ecs list-tasks --cluster "$cluster" --family "webcms-drupal-$WEBCMS_ENVIRONMENT" |
-  # Extract the ARN array and print out an ARN, one per line
-  jq -r '.taskArns[]' |
+# stop-task API only accepts one task. This pipeline uses jq to print task ARNs line by line.
+task_list="$(
+  aws ecs list-tasks --cluster "$cluster" --family "webcms-drupal-$WEBCMS_ENVIRONMENT" |
+  jq -r '.taskArns[]'
+)"
+
+# If there are currently running tasks, then remove them. (This conditional prevents xargs
+# from iterating over an empy list, causing issues with aws ecs stop-task)
+if test -n "$task_list"; then
   # Stop tasks two at a time. Here, -L1 means process one line at a time, and -P2 asks
   # xargs to use up to two child processes at once. This lets us parallelize the otherwise
   # sequential job of stopping ECS tasks. (The task ARN is prepended by xargs, so we don't
   # need to specify a template string.)
-  xargs -L1 -P2 aws ecs stop-task --cluster "$cluster" --query 'task.taskArn' --task
+  xargs -L1 -P2 aws ecs stop-task --cluster "$cluster" --query 'task.taskArn' --task <<<"$task_list"
+fi
 
 echo "--- Running Drush"
 


### PR DESCRIPTION
This PR makes a few changes to `run-drush.sh`:

1. It limits the output of `aws ecs stop-task` to just the task ARNs that were stopped. This is mostly useful when testing the `run-drush.sh` script locally.
2. It prevents `xargs` from iterating over an empty list of tasks during the stop task phase. This could happen if many builds occurred very close to each other, and ECS didn't yet have time to spawn new tasks for the Drupal service.
3. The output of `aws ecs run-task` is now inspected for failures before waiting on a newly-spawned task. Note that this failure mode applies only to API failures; if RunTask itself returns an error, then it means that AWS was unable to complete our request (due to, e.g., bad permissions).