### PR TITLE
[EPAD8-987] Be pickier about external link style

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/_external-link.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/_external-link.scss
@@ -21,7 +21,7 @@
   }
 }
 
-a:not([href=''], [href*='.gov'], [href^='#'], [href^='?'], [href^='/'], [href^='.'], [href^='javascript:'], [href^='mailto:'], [href^='tel:'], [href*='webcms-uploads-dev.s3.amazonaws.com'], [href*='webcms-uploads-stage.s3.amazonaws.com'], [href*='webcms-uploads-prod.s3.amazonaws.com']) {
+a:not([href=''], [href*='.gov'], [data-drupal-link-system-path^='node/'], [href^='#'], [href^='?'], [href^='/'], [href^='.'], [href^='javascript:'], [href^='mailto:'], [href^='tel:'], [href*='webcms-uploads-dev.s3.amazonaws.com'], [href*='webcms-uploads-stage.s3.amazonaws.com'], [href*='webcms-uploads-prod.s3.amazonaws.com']) {
   @extend .external-link;
 }
 


### PR DESCRIPTION
In page zip exports, the current page href will just be an HTML
filename and--lacking ".gov"--it would normally get the external link
styling. This ensures that doesn't happen, at least for exported nodes.

https://forumone.atlassian.net/browse/EPAD8-987