### PR TITLE
Calculate batches by unprocessed, not total

### DIFF
--- a/scripts/halt-stage-migration.sh
+++ b/scripts/halt-stage-migration.sh
@@ -45,7 +45,7 @@ arn="$(
     --task-definition webcms-drush-stage \
     --cluster webcms-cluster-stage \
     --overrides "$overrides" \
-    --capacity-provider-strategy=FARGATE,weight=1,base=1 \
+    --capacity-provider-strategy "capacityProvider=FARGATE,weight=1,base=1" \
     --network-configuration "$(cat drushvpc-stage.json)" \
     --started-by "$started_by" |
     jq -r '.tasks[0].taskArn'

--- a/scripts/stage-command.sh.example
+++ b/scripts/stage-command.sh.example
@@ -41,7 +41,7 @@ arn="$(
     --task-definition webcms-drush-stage \
     --cluster webcms-cluster-stage \
     --overrides "$overrides" \
-    --capacity-provider-strategy=FARGATE,weight=1,base=1 \
+    --capacity-provider-strategy "capacityProvider=FARGATE,weight=1,base=1" \
     --network-configuration "$(cat drushvpc-stage.json)" \
     --started-by "$started_by" |
     jq -r '.tasks[0].taskArn'

--- a/scripts/start-stage-migration.sh
+++ b/scripts/start-stage-migration.sh
@@ -40,7 +40,7 @@ arn="$(
     --task-definition webcms-drush-stage \
     --cluster webcms-cluster-stage \
     --overrides "$overrides" \
-    --capacity-provider-strategy=FARGATE,weight=1,base=1 \
+    --capacity-provider-strategy "capacityProvider=FARGATE,weight=1,base=1" \
     --network-configuration "$(cat drushvpc-stage.json)" \
     --started-by "$started_by" |
     jq -r '.tasks[0].taskArn'


### PR DESCRIPTION
This allows us to re-run the script without needlessly rerunning
all batches that do nothing.

Also fixes the fargate config in tasks.