### PR TITLE
Allow setting allowable unprocessed counts without a build

### DIFF
--- a/scripts/allow-unprocessed.sh
+++ b/scripts/allow-unprocessed.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
 
-# Local script to kick off the ECS task to run the drush migration script [1] on
-# the webcms-cluster-stage cluster.
+# Local script to set expected unprocessed counts for the migration.
 #
 # Requirements:
 #   - drushvpc-stage.json must be in cwd
 #   - AWS_PROFILE is set appropriately
 #
-# USAGE: bash scripts/start-stage-migration.sh
-#
-# if you need to stop this, use scripts/halt-stage-migration.sh
-#
-# [1] See /services/drupal/scripts/ecs/drush-migrate.sh
+# USAGE: bash scripts/allow-unprocessed.sh
 
 set -euo pipefail
 
 started_by="bschumacher"
-script='drush-migrate'
+
+# e.g. drush state-set epa.allowed_unprocessed.upgrade_d7_node_revision_document 1
+
+script=$(cat <<EOF
+  drush state-set epa.allowed_unprocessed.upgrade_d7_node_revision_document 1
+EOF
+)
 
 # Use jq to format the container overrides in a way that plays nicely with
 # AWS ECS' character count limitations on JSON input, as well as avoids

--- a/scripts/halt-stage-migration.sh
+++ b/scripts/halt-stage-migration.sh
@@ -52,3 +52,4 @@ arn="$(
 )"
 
 echo "Task ARN: $arn"
+echo "Find it here: https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/webcms-cluster-stage/tasks"

--- a/scripts/stage-command.sh.example
+++ b/scripts/stage-command.sh.example
@@ -48,3 +48,4 @@ arn="$(
 )"
 
 echo "ARN: $arn"
+echo "Find it here: https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/webcms-cluster-stage/tasks"

--- a/services/drupal/scripts/ecs/drush-migrate.sh
+++ b/services/drupal/scripts/ecs/drush-migrate.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
+# Note: First use allow-unprocessed.sh to set allowable unprocessed counts
+# before usage. These are stored in the D8 DB.
+
 set -euo pipefail
 
 # Number of items to process in a single batch run
 batch_size=1000
+
+# https://stackoverflow.com/a/33248547/3779
+trim() {
+  local s2 s="$*"
+  until s2="${s#[[:space:]]}"; [ "$s2" = "$s" ]; do s="$s2"; done
+  until s2="${s%[[:space:]]}"; [ "$s2" = "$s" ]; do s="$s2"; done
+  echo "$s"
+}
 
 # USAGE:
 #   run_migration MIGRATION
@@ -12,7 +23,7 @@ batch_size=1000
 #
 # This function runs a migration to completion, using the configured $batch_size variable
 # above. If a migration yields unprocessed entities greater than the threshold specified
-# in the expected_unprocessed array, then this function returns a non-zero exit code.
+# by the allow-unprocessed.sh script, then this function returns a non-zero exit code.
 run_migration() {
   local migration
   local total batches unprocessed remaining
@@ -24,8 +35,8 @@ run_migration() {
   migration="$1"
 
   # If already done, skip.
-  unprocessed="$(drush ms "$migration" --field=unprocessed)"
-  if [[ "$unprocessed" =~ ^0 ]]; then
+  unprocessed="$(trim $(drush ms "$migration" --field=unprocessed))"
+  if test "$unprocessed" = 0; then
     echo "[$migration] Bypassing, 0 remaining"
     return 0
   fi
@@ -52,10 +63,10 @@ run_migration() {
 
     # Check if we've asked to halt. Migration's own status field isn't really reliable
     # for discerning whether a migration has been stopped or completed.
-    halted="$(drush state-get epa.migrations_halted)"
+    halted="$(trim $(drush state-get epa.migrations_halted))"
     if test -n "$halted"; then
       # Output the num remaining and exit
-      remaining="$(drush ms "$migration" --field=unprocessed)"
+      remaining="$(trim $(drush ms "$migration" --field=unprocessed))"
       echo "[$migration] Halted ($remaining unprocessed of $unprocessed)"
       echo "Halting migration script, deleting halt signal"
       drush state-del epa.migrations_halted
@@ -68,11 +79,12 @@ run_migration() {
   time=$((finish - start))
 
   # Determine how many unprocessed items were left behind by the migration.
-  remaining="$(drush ms "$migration" --field=unprocessed)"
-  total="$(drush ms "$migration" --field=total)"
+  remaining="$(trim $(drush ms "$migration" --field=unprocessed))"
+  total="$(trim $(drush ms "$migration" --field=total))"
 
   # If we don't have any special expected count, default to zero.
-  expected="${expected_unprocessed[$migration]:-0}"
+  expected="$(trim $(drush state-get epa.allowed_unprocessed.$migration))"
+  expected="${$expected:-0}"
 
   # If the unprocessed count is above the threshold, return a failure.
   if test "$remaining" -gt "$expected"; then
@@ -226,14 +238,6 @@ latest_revision_migrations=(
 
 path_redirect_migrations=(
   upgrade_d7_path_redirect
-)
-
-# Collection of allowed thresholds for unprocessed items in a migration. The array is
-# keyed by migration name, and the values are the expected unprocessed count. If 0
-# entities are expected to remain unprocessed, then it is safe to omit that migration from
-# this array. See the run_migration function for how this is used.
-declare -A expected_unprocessed=(
-  # (syntax note: the square brackets are required)
 )
 
 # Import taxonomy terms, groups, and users.


### PR DESCRIPTION
Eliminates need for 20+ minute build to update allowed counts and restart migration.