### PR TITLE
Fix high water mark on our banner migration to ensure all get migrated

### DIFF
--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner_slide.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner_slide.yml
@@ -18,7 +18,7 @@ source:
   bundle: web_area
   field: field_web_area_slideshow
   high_water_property:
-    name: revision_id
+    name: unique_id
     alias: fd
 process:
   field_text/value:

--- a/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner_slide.yml
+++ b/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner_slide.yml
@@ -16,7 +16,7 @@ source:
   bundle: web_area
   field: field_web_area_slideshow
   high_water_property:
-    name: revision_id
+    name: unique_id
     alias: fd
 process:
   field_text/value:

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaMultivalueField.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaMultivalueField.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\epa_migrations\Plugin\migrate\source;
 
-use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
 use Drupal\migrate\MigrateException;
 
@@ -25,6 +25,13 @@ class EpaMultivalueField extends DrupalSqlBase {
    */
   protected $batchSize = 1000;
 
+  const HIGH_WATER_EXPRESSION = "CONCAT(fd.revision_id, '-', fd.delta)";
+
+  /**
+   * Intentionally does not include "fd."
+   */
+  const HIGH_WATER_ALIAS = "unique_id";
+
   /**
    * {@inheritdoc}
    */
@@ -36,7 +43,7 @@ class EpaMultivalueField extends DrupalSqlBase {
         ->fields('fd');
 
       // Add an expression to let us generate a unique field for use as high water mark.
-      $query->addExpression('CONCAT(fd.revision_id, "-", fd.delta)', 'unique_id');
+      $query->addExpression(self::HIGH_WATER_EXPRESSION, 'unique_id');
 
       if ($this->configuration['bundle']) {
         $query->condition('fd.bundle', $this->configuration['bundle']);
@@ -70,6 +77,129 @@ class EpaMultivalueField extends DrupalSqlBase {
     $ids['delta']['type'] = 'integer';
     $ids['delta']['alias'] = 'fd';
     return $ids;
+  }
+
+  /**
+   * This has been overwritten from SqlBase in order to use the expression of fields
+   * in the high water condition because MySQL does not allow a condition on an
+   * aliased expression.
+   *
+   * @see SqlBase::initializeIterator
+   */
+  protected function initializeIterator() {
+    if (date('Y-m-d') > '2021-06-01') {
+      // This code should not be reused without first syncing in changes from its ancestor
+      // method SqlBase::initializeIterator.
+      throw new MigrateException("Code should be synced with SqlBase::initializeIterator as it"
+        . " may be out of sync."
+      );
+    }
+
+    // Initialize the batch size.
+    if ($this->batchSize == 0 && isset($this->configuration['batch_size'])) {
+      // Valid batch sizes are integers >= 0.
+      if (is_int($this->configuration['batch_size']) && ($this->configuration['batch_size']) >= 0) {
+        $this->batchSize = $this->configuration['batch_size'];
+      }
+      else {
+        throw new MigrateException("batch_size must be greater than or equal to zero");
+      }
+    }
+
+    // If a batch has run the query is already setup.
+    if ($this->batch == 0) {
+      $this->prepareQuery();
+
+      // Get the key values, for potential use in joining to the map table.
+      $keys = [];
+
+      // The rules for determining what conditions to add to the query are as
+      // follows (applying first applicable rule):
+      // 1. If the map is joinable, join it. We will want to accept all rows
+      //    which are either not in the map, or marked in the map as NEEDS_UPDATE.
+      //    Note that if high water fields are in play, we want to accept all rows
+      //    above the high water mark in addition to those selected by the map
+      //    conditions, so we need to OR them together (but AND with any existing
+      //    conditions in the query). So, ultimately the SQL condition will look
+      //    like (original conditions) AND (map IS NULL OR map needs update
+      //      OR above high water).
+      $conditions = $this->query->orConditionGroup();
+      $condition_added = FALSE;
+      $added_fields = [];
+      if ($this->mapJoinable()) {
+        // Build the join to the map table. Because the source key could have
+        // multiple fields, we need to build things up.
+        $count = 1;
+        $map_join = '';
+        $delimiter = '';
+        foreach ($this->getIds() as $field_name => $field_schema) {
+          if (isset($field_schema['alias'])) {
+            $field_name = $field_schema['alias'] . '.' . $this->query->escapeField($field_name);
+          }
+          $map_join .= "$delimiter$field_name = map.sourceid" . $count++;
+          $delimiter = ' AND ';
+        }
+
+        $alias = $this->query->leftJoin($this->migration->getIdMap()
+          ->getQualifiedMapTableName(), 'map', $map_join);
+        $conditions->isNull($alias . '.sourceid1');
+        $conditions->condition($alias . '.source_row_status', MigrateIdMapInterface::STATUS_NEEDS_UPDATE);
+        $condition_added = TRUE;
+
+        // And as long as we have the map table, add its data to the row.
+        $n = count($this->getIds());
+        for ($count = 1; $count <= $n; $count++) {
+          $map_key = 'sourceid' . $count;
+          $this->query->addField($alias, $map_key, "migrate_map_$map_key");
+          $added_fields[] = "$alias.$map_key";
+        }
+        if ($n = count($this->migration->getDestinationIds())) {
+          for ($count = 1; $count <= $n; $count++) {
+            $map_key = 'destid' . $count++;
+            $this->query->addField($alias, $map_key, "migrate_map_$map_key");
+            $added_fields[] = "$alias.$map_key";
+          }
+        }
+        $this->query->addField($alias, 'source_row_status', 'migrate_map_source_row_status');
+        $added_fields[] = "$alias.source_row_status";
+      }
+      // 2. If we are using high water marks, also include rows above the mark.
+      //    But, include all rows if the high water mark is not set.
+      if ($this->getHighWaterProperty()) {
+        $high_water_field = $this->getHighWaterField();
+        $high_water = $this->getHighWater();
+        // We check against NULL because 0 is an acceptable value for the high
+        // water mark.
+        if ($high_water !== NULL) {
+          $conditions->condition(self::HIGH_WATER_EXPRESSION, $high_water, '>');
+          $condition_added = TRUE;
+        }
+        // Always sort by the high water field, to ensure that the first run
+        // (before we have a high water value) also has the results in a
+        // consistent order.
+        $this->query->orderBy(self::HIGH_WATER_ALIAS);
+      }
+      if ($condition_added) {
+        $this->query->condition($conditions);
+      }
+      // If the query has a group by, our added fields need it too, to keep the
+      // query valid.
+      // @see https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
+      $group_by = $this->query->getGroupBy();
+      if ($group_by && $added_fields) {
+        foreach ($added_fields as $added_field) {
+          $this->query->groupBy($added_field);
+        }
+      }
+    }
+
+    // Download data in batches for performance.
+    if (($this->batchSize > 0)) {
+      $this->query->range($this->batch * $this->batchSize, $this->batchSize);
+    }
+    $statement = $this->query->execute();
+    $statement->setFetchMode(\PDO::FETCH_ASSOC);
+    return new \IteratorIterator($statement);
   }
 
 }

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaMultivalueField.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaMultivalueField.php
@@ -35,6 +35,9 @@ class EpaMultivalueField extends DrupalSqlBase {
       $query = $this->select($field_table, 'fd')
         ->fields('fd');
 
+      // Add an expression to let us generate a unique field for use as high water mark.
+      $query->addExpression('CONCAT(fd.revision_id, "-", fd.delta)', 'unique_id');
+
       if ($this->configuration['bundle']) {
         $query->condition('fd.bundle', $this->configuration['bundle']);
       }

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaMultivalueField.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaMultivalueField.php
@@ -171,16 +171,15 @@ class EpaMultivalueField extends DrupalSqlBase {
         // We check against NULL because 0 is an acceptable value for the high
         // water mark.
         if ($high_water !== NULL) {
-          $conditions->condition(self::HIGH_WATER_EXPRESSION, $high_water, '>');
-          $condition_added = TRUE;
+          // Note this used to use the conditions API
+          $this->query->where(self::HIGH_WATER_EXPRESSION . " > :hw", [
+            'hw' => $high_water,
+          ]);
         }
         // Always sort by the high water field, to ensure that the first run
         // (before we have a high water value) also has the results in a
         // consistent order.
         $this->query->orderBy(self::HIGH_WATER_ALIAS);
-      }
-      if ($condition_added) {
-        $this->query->condition($conditions);
       }
       // If the query has a group by, our added fields need it too, to keep the
       // query valid.


### PR DESCRIPTION
Please take a look at this and tell me what you think.  We missed some records in the upgrade_d7_node_web_area_paragraph_banner_slide migration due to the fact that we used the revision ID as the high water mark.  Revision ID isn't unique since there can be multiple field values attached to a single revision with different deltas.  This change adds an expression that concatenates revision ID and delta to achieve a truly unique value to be used as the Highwater mark.