### PR TITLE
[EPAD8] Migration config cruft

### DIFF
--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_group_content_file.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_group_content_file.yml
@@ -6,7 +6,7 @@ dependencies:
     module:
       - epa_migrations
 _core:
-  default_config_hash: 9JrH9ADF4mYjs9H6kkiBE4bJZRY0w3MkxtPlrPnGC18
+  default_config_hash: IpK_FOSBgUFvwzIOcBZCE3NabXAPz3Y2YInmHxOU5wU
 id: upgrade_d7_group_content_file
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null
@@ -22,6 +22,7 @@ source:
     name: etid
   d7_entity_type: file
   d8_entity_type: media
+  use_og_table: true
   constants:
     formatted_group_prefix: web_area-group_
     formatted_d8_entity_type: media-

--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_group_content_file.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_group_content_file.yml
@@ -22,7 +22,6 @@ source:
     name: etid
   d7_entity_type: file
   d8_entity_type: media
-  use_og_table: true
   constants:
     formatted_group_prefix: web_area-group_
     formatted_d8_entity_type: media-

--- a/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner_slide.yml
+++ b/services/drupal/config/sync/migrate_plus.migration.upgrade_d7_node_web_area_paragraph_banner_slide.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: FZ27QGEf78UqZJTjoX3y-QLKz4orRAwucKOcyhYacjs
+  default_config_hash: tyHw72x9XZauZKIbcJvPyFgsa6OdTjQNWFJ4gV8ormU
 id: upgrade_d7_node_web_area_paragraph_banner_slide
 class: Drupal\migrate\Plugin\Migration
 field_plugin_method: null

--- a/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_group_content_file.yml
+++ b/services/drupal/web/modules/custom/epa_migrations/config/install/migrate_plus.migration.upgrade_d7_group_content_file.yml
@@ -20,6 +20,7 @@ source:
     name: etid
   d7_entity_type: file
   d8_entity_type: media
+  use_og_table: true
   constants:
     # The group machine name with '-group_' appended.
     formatted_group_prefix: 'web_area-group_'


### PR DESCRIPTION
When I uninstalled and re-installed the epa migrations module locally, these config changes were detected. I split them into a separate PR because I'm not familiar with the `use_og_table` source setting and wanted to make sure this is a desired change.