### PR TITLE
[EPAD8] Update panelizer source queries

### DIFF
--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNode.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNode.php
@@ -28,7 +28,7 @@ class EpaPanelizerNode extends Node {
     // Get the default Node query.
     $query = parent::query();
 
-    $query->leftJoin('panelizer_entity', 'pe', 'nr.vid = pe.revision_id AND pe.entity_id = n.nid AND pe.entity_type = :type', [':type' => 'node']);
+    $query->leftJoin('panelizer_entity', 'pe', 'n.vid = pe.revision_id AND pe.entity_id = n.nid AND pe.entity_type = :type', [':type' => 'node']);
     $query->leftJoin('panels_display', 'pd', 'pe.did = pd.did');
     $query->innerJoin('node_revision_epa_states', 'nres', 'nres.vid = nr.vid');
 

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNode.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNode.php
@@ -28,21 +28,26 @@ class EpaPanelizerNode extends Node {
     // Get the default Node query.
     $query = parent::query();
 
-    // For all node types, exclude nodes that use these layouts:
-    // * onecol_page
-    // * six_pack
-    // Exclude nodes that use the twocol_page layout for all node types except
-    // web_area.
-    $query->innerJoin('panelizer_entity', 'pe', 'n.vid = pe.revision_id AND pe.entity_id = n.nid AND pe.entity_type = :type', [':type' => 'node']);
-    $query->innerJoin('panels_display', 'pd', 'pe.did = pd.did');
-    $query->condition('pe.did', 0, '<>');
-    $query->condition('pd.layout', 'onecol_page', '<>');
-    $query->condition('pd.layout', 'six_pack', '<>');
+    $query->leftJoin('panelizer_entity', 'pe', 'nr.vid = pe.revision_id AND pe.entity_id = n.nid AND pe.entity_type = :type', [':type' => 'node']);
+    $query->leftJoin('panels_display', 'pd', 'pe.did = pd.did');
+    $query->innerJoin('node_revision_epa_states', 'nres', 'nres.vid = nr.vid');
 
-    if ($this->configuration['node_type'] !== 'web_area') {
-      $query->condition('pd.layout', 'twocol_page', '<>');
-    }
+    $query->addField('nres','state');
+    $query->addField('pe', 'did');
+    $query->addField('pd', 'layout');
 
+    // Only include records where one of the following is true:
+    // * Does not use panelizer twocol_page layout unless it is a web area node
+    // * Does not use panelizer onecol_page or six_pack layout.
+    $and = $query->andConditionGroup()
+      ->condition('pd.layout', 'twocol_page')
+      ->condition('n.type', 'web_area');
+
+    $or = $query->orConditionGroup()
+      ->condition($and)
+      ->condition('pd.layout', ['onecol_page', 'twocol_page', 'six_pack'], 'NOT IN');
+
+    $query->condition($or);
     return $query;
   }
 

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNodeRevision.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNodeRevision.php
@@ -27,20 +27,27 @@ class EpaPanelizerNodeRevision extends NodeRevision {
     // Get the default Node query.
     $query = parent::query();
 
-    // For all node types, exclude nodes that use these layouts:
-    // * onecol_page
-    // * six_pack
-    // Exclude nodes that use the twocol_page layout for all node types except
-    // web_area.
-    $query->innerJoin('panelizer_entity', 'pe', 'n.vid = pe.revision_id AND pe.entity_id = n.nid AND pe.entity_type = :type', [':type' => 'node']);
-    $query->innerJoin('panels_display', 'pd', 'pe.did = pd.did');
-    $query->condition('pe.did', 0, '<>');
-    $query->condition('pd.layout', 'onecol_page', '<>');
-    $query->condition('pd.layout', 'six_pack', '<>');
+    $query->leftJoin('panelizer_entity', 'pe', 'nr.vid = pe.revision_id AND pe.entity_id = n.nid AND pe.entity_type = :type', [':type' => 'node']);
+    $query->leftJoin('panels_display', 'pd', 'pe.did = pd.did');
+    $query->innerJoin('node_revision_epa_states', 'nres', 'nres.vid = nr.vid');
 
-    if ($this->configuration['node_type'] !== 'web_area') {
-      $query->condition('pd.layout', 'twocol_page', '<>');
-    }
+    $query->addField('nres','state');
+    $query->addField('pe', 'did');
+    $query->addField('pd', 'layout');
+
+    // Only include records where one of the following is true:
+    // * Does not use panelizer twocol_page layout unless it is a web area node
+    // * Does not use panelizer onecol_page or six_pack layout.
+
+    $and = $query->andConditionGroup()
+      ->condition('pd.layout', 'twocol_page')
+      ->condition('n.type', 'web_area');
+
+    $or = $query->orConditionGroup()
+      ->condition($and)
+      ->condition('pd.layout', ['onecol_page', 'twocol_page', 'six_pack'], 'NOT IN');
+
+    $query->condition($or);
 
     return $query;
   }

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNodeRevision.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/source/EpaPanelizerNodeRevision.php
@@ -62,15 +62,7 @@ class EpaPanelizerNodeRevision extends NodeRevision {
       return FALSE;
     }
 
-    // Get the revision moderation state and timestamp.
-    $state_data = $this->select('node_revision_epa_states', 'nres')
-      ->fields('nres', ['state'])
-      ->condition('nres.vid', $row->getSourceProperty('vid'))
-      ->execute()
-      ->fetchAll();
-
-    if ($state_data) {
-      $state_data = array_shift($state_data);
+    if ($state = $row->getSourceProperty('state')) {
       $state_map = [
         'unpublished' => 'unpublished',
         'draft' => 'draft',
@@ -82,37 +74,12 @@ class EpaPanelizerNodeRevision extends NodeRevision {
         'queued_for_archive' => 'unpublished',
       ];
 
-      $row->setSourceProperty('nres_state', $state_map[$state_data['state']]);
+      $row->setSourceProperty('nres_state', $state_map[$state]);
     }
 
-    // To prepare rows for import into fields, we're going to:
-    // - Add a 'layout' source property for use during processing.
-    // - Add a 'panes' source property containing query results for all panes.
-    //
-    // First, initialize the 'layout' source property as NULL so we can properly
-    // process nodes that do not have a record in the 'panelizer_entity' table.
-    $row->setSourceProperty('layout', NULL);
-
-    // Get the Display ID for the current revision.
-    $did = $this->select('panelizer_entity', 'pe')
-      ->fields('pe', ['did'])
-      ->condition('pe.revision_id', $row->getSourceProperty('vid'))
-      ->condition('pe.entity_id', $row->getSourceProperty('nid'))
-      ->condition('pe.entity_type', 'node')
-      ->execute()
-      ->fetchField();
+    $did = $row->getSourceProperty('did');
 
     if ($did) {
-      // Get the Panelizer layout for this display.
-      $layout = $this->select('panels_display', 'pd')
-        ->fields('pd', ['layout'])
-        ->condition('pd.did', $did)
-        ->execute()
-        ->fetchField();
-
-      // Update the 'layout' property to its actual value.
-      $row->setSourceProperty('layout', $layout);
-
       // Fetch the panes and add the result as a source property.
       $panes = $this->select('panels_pane', 'pp')
         ->fields('pp')


### PR DESCRIPTION
I updated the EpaPanelizerNode and EpaPanelizerNodeRevision source queries to be in alignment with the updates made to the non-panelizer source plugins. Testing locally, I checked that the number of revisions that exist for Basic Pages and Documents matches the numbers that are returned for the revision migrations on the migration status page.