### PR TITLE
[EPAD8] Ensure we're passing the latest node entity to the pathauto method

### DIFF
--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/process/EpaSetLatestRevision.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/process/EpaSetLatestRevision.php
@@ -181,7 +181,9 @@ class EpaSetLatestRevision extends ProcessPluginBase implements ContainerFactory
       }
     }
 
-    // Now that we've set the correct latest revision, let's turn on pathauto.
+    // Now that we've set the correct revisions, let's refresh our node
+    // entity and turn on pathauto.
+    $node = $node_storage->load($nid);
     $this->pathautoOn($node);
 
     return TRUE;


### PR DESCRIPTION
In migration 5, we saw that nodes were not getting the correct revision set as the current revision. This is because we moved the call to `$this->pathautoOn($node);` to happen after the logic to set the latest and current revision. Since we were passing the `pathautoOn` method the same `$node` variable that we instantiated at the start of the process, the variable had outdated entity data. When we called `$node->save()` in the `pathautoOn` method, we were re-saving the node with an outdated value for the current revision id.

This PR ensures we re-load the node entity prior to calling `pathautoOn` so that we're re-saving the entity with the correct values.