### PR TITLE
Add `--force` flag to migrate import

### DIFF
--- a/services/drupal/scripts/ecs/drush-migrate.sh
+++ b/services/drupal/scripts/ecs/drush-migrate.sh
@@ -58,6 +58,7 @@ run_migration() {
     echo "[$migration] Importing ($((i + 1))/$batches batches)"
     drush mim \
       --limit=$batch_size \
+      --force \
       "$migration"
 
     # Check if we've asked to halt. Migration's own status field isn't really reliable


### PR DESCRIPTION
We're not relying on migration dependencies, we're running our migration manually in the order needed. This will prevent the migration from stopping when any implied dependencies are not met.