### PR TITLE
Epad8 1233 migrate authmap

### DIFF
--- a/services/drupal/config/sync/samlauth.authentication.yml
+++ b/services/drupal/config/sync/samlauth.authentication.yml
@@ -26,8 +26,8 @@ idp_change_password_service: ''
 idp_cert_type: single
 idp_x509_certificate: ''
 idp_x509_certificate_multi: ''
-unique_id_attribute: mail
-map_users: true
+unique_id_attribute: uid
+map_users: false
 create_users: true
 sync_name: false
 sync_mail: false

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
@@ -97,6 +97,12 @@ class EpaUserGroupMembership extends EntityUser {
       }
     }
 
+    // Create authmap entry for everyone but superuser.
+    if ($entity->id() != 1) {
+      $external_auth = \Drupal::service('externalauth.externalauth');
+      $external_auth->linkExistingAccount($entity->name, 'samlauth', $entity);
+    }
+
     return [$entity->id()];
   }
 

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
@@ -100,7 +100,7 @@ class EpaUserGroupMembership extends EntityUser {
     // Create authmap entry for everyone but superuser.
     if ($entity->id() != 1) {
       $external_auth = \Drupal::service('externalauth.externalauth');
-      $external_auth->linkExistingAccount($entity->name, 'samlauth', $entity);
+      $external_auth->linkExistingAccount($entity->name->value, 'samlauth', $entity);
     }
 
     return [$entity->id()];


### PR DESCRIPTION
This code is meant to add entries to the authmap table to establish the correct mapping between Drupal and SAML users.  You can test this by running the user migration and ensuring that entries are created in the authmap table.