### PR TITLE
Epad8 1233 migrate authmap

### DIFF
--- a/services/drupal/config/sync/samlauth.authentication.yml
+++ b/services/drupal/config/sync/samlauth.authentication.yml
@@ -26,8 +26,8 @@ idp_change_password_service: ''
 idp_cert_type: single
 idp_x509_certificate: ''
 idp_x509_certificate_multi: ''
-unique_id_attribute: mail
-map_users: true
+unique_id_attribute: uid
+map_users: false
 create_users: true
 sync_name: false
 sync_mail: false

--- a/services/drupal/config/sync/seckit.settings.yml
+++ b/services/drupal/config/sync/seckit.settings.yml
@@ -49,7 +49,7 @@ seckit_fp:
 seckit_various:
   from_origin: false
   from_origin_destination: same
-  referrer_policy: true
+  referrer_policy: false
   referrer_policy_policy: strict-origin-when-cross-origin
   disable_autocomplete: false
 _core:

--- a/services/drupal/web/modules/custom/epa_core/src/EventSubscriber/EpaCoreEventSubscriber.php
+++ b/services/drupal/web/modules/custom/epa_core/src/EventSubscriber/EpaCoreEventSubscriber.php
@@ -59,7 +59,7 @@ class EpaCoreEventSubscriber implements EventSubscriberInterface {
 
     // Execute necessary functions.
     if ($this->config->get('seckit_csrf.origin')) {
-      //$this->seckitOrigin($event);
+      $this->seckitOrigin($event);
     }
   }
 

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
@@ -97,6 +97,12 @@ class EpaUserGroupMembership extends EntityUser {
       }
     }
 
+    // Create authmap entry for everyone but superuser.
+    if ($entity->id() != 1) {
+      $external_auth = \Drupal::service('externalauth.externalauth');
+      $external_auth->linkExistingAccount($entity->name, 'samlauth', $entity);
+    }
+
     return [$entity->id()];
   }
 

--- a/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
+++ b/services/drupal/web/modules/custom/epa_migrations/src/Plugin/migrate/destination/EpaUserGroupMembership.php
@@ -100,7 +100,7 @@ class EpaUserGroupMembership extends EntityUser {
     // Create authmap entry for everyone but superuser.
     if ($entity->id() != 1) {
       $external_auth = \Drupal::service('externalauth.externalauth');
-      $external_auth->linkExistingAccount($entity->name, 'samlauth', $entity);
+      $external_auth->linkExistingAccount($entity->name->value, 'samlauth', $entity);
     }
 
     return [$entity->id()];


### PR DESCRIPTION
When this gets merged it will turn off auto-mapping of SAML users based on email address and instead rely completely on the mappings in the authmap table.  This means that, for instance, if there are users on beta.epa.gov who have not already logged in using SAML and had their mapping to their existing user established, once this code is merged if they then log in they will end up getting a new account created for them rather than getting mapped onto an existing user (or they won't get an account created at all and won't be able to log in because their username collides with an existing username).

As long as this code is deployed along with the DB from migration 8 (which handles migrating all the data in the authmap table, thus ensuring all users get a SAML mapping) then there will be no problems.