### PR TITLE
Apply pull quote style to blockquotes generally

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/02-base/02-html-elements/16-blockquote/_blockquote.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/02-base/02-html-elements/16-blockquote/_blockquote.scss
@@ -3,14 +3,33 @@
 
 $blockquote-cite-divider-color: gesso-color(ui, generic, border);
 
-blockquote {
+%pull-quote {
   @include display-text-style(blockquote);
+  background-color: gesso-grayscale(white);
+  border-left: rem(units(1)) solid gesso-brand(aqua, base);
+  clear: both;
   margin: 0 0 rem(gesso-spacing(3));
+  padding: rem(units($theme-alert-padding-x)) 0
+    rem(units($theme-alert-padding-x)) rem(units($theme-alert-padding-x));
+
+  > :last-child {
+    margin-bottom: 0;
+  }
 
   // Add top margin when preceded by another element.
   * + & {
     margin-top: rem(gesso-spacing(3));
   }
+}
+
+%pull-quote__cite {
+  display: block;
+  margin: rem(gesso-spacing(2)) 0;
+  text-align: left;
+}
+
+blockquote {
+  @extend %pull-quote;
 
   p {
     color: inherit;
@@ -21,9 +40,7 @@ blockquote {
   }
 
   cite {
-    display: block;
-    margin: rem(gesso-spacing(2)) 0;
-    text-align: right;
+    @extend %pull-quote__cite;
 
     em {
       border-left: 1px solid $blockquote-cite-divider-color;

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/pull-quote/_pull-quote.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/pull-quote/_pull-quote.scss
@@ -1,17 +1,8 @@
 // @file
 // Styles for a pull quote.
 
-blockquote, .pull-quote {
-  background-color: gesso-grayscale(white);
-  border-left: rem(units(1)) solid gesso-brand(aqua, base);
-  clear: both;
-  margin-bottom: rem(units(3));
-  padding: rem(units($theme-alert-padding-x)) 0
-    rem(units($theme-alert-padding-x)) rem(units($theme-alert-padding-x));
-
-  > :last-child {
-    margin-bottom: 0;
-  }
+.pull-quote {
+  @extend %pull-quote;
 
   @include breakpoint(gesso-breakpoint(tablet)) {
     &.u-align-left,
@@ -22,6 +13,6 @@ blockquote, .pull-quote {
   }
 }
 
-blockquote cite, .pull-quote__cite {
-  text-align: left;
+.pull-quote__cite {
+  @extend %pull-quote__cite;
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/pull-quote/_pull-quote.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/pull-quote/_pull-quote.scss
@@ -1,7 +1,7 @@
 // @file
 // Styles for a pull quote.
 
-.pull-quote {
+blockquote, .pull-quote {
   background-color: gesso-grayscale(white);
   border-left: rem(units(1)) solid gesso-brand(aqua, base);
   clear: both;
@@ -22,6 +22,6 @@
   }
 }
 
-.pull-quote__cite {
+blockquote cite, .pull-quote__cite {
   text-align: left;
 }


### PR DESCRIPTION
@dcmouyard : is this the right way to make all `blockquote`s look like pull quotes? We find the default `blockquote` styling to be a little jarring, and we're finding that people have been using `blockquote`s a lot.