### PR TITLE
EPAD8-1338: Add CPU-based scaling policy for Traefik

### DIFF
--- a/terraform/infrastructure/traefik_service.tf
+++ b/terraform/infrastructure/traefik_service.tf
@@ -124,7 +124,7 @@ resource "aws_appautoscaling_target" "traefik" {
 }
 
 resource "aws_appautoscaling_policy" "traefik" {
-  name = "webcms-${var.environment}-traefik-cpu"
+  name        = "webcms-${var.environment}-traefik-cpu"
   policy_type = "TargetTrackingScaling"
 
   resource_id        = aws_appautoscaling_target.traefik.id

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -121,3 +121,20 @@ variable "cache_instance_count" {
 }
 
 #endregion
+
+#region Traefik
+# cf. traefik_service.tf
+
+variable "traefik_min_capacity" {
+  description = "Minimum number of Traefik tasks to run"
+  type        = number
+  default     = 2
+}
+
+variable "traefik_max_capacity" {
+  description = "Maximum number of Traefik tasks to run"
+  type        = number
+  default     = 5
+}
+
+#endregion


### PR DESCRIPTION
Per our load test results, this PR adds a scaling policy to the Traefik service to prevent it from being a bottleneck during high-load situations.