### PR TITLE
EPAD8-1175: Install New Relic extension

### DIFF
--- a/.buildkite/infrastructure.yml
+++ b/.buildkite/infrastructure.yml
@@ -8,33 +8,6 @@ steps:
       WEBCMS_TF_MODULE: network
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/network
 
-  # Copy images from the Docker Hub into the AWS perimeter
-  - label: ":docker: Mirror Images"
-    command:
-      # Traefik (used for routing behind the NLB)
-      - docker pull traefik:2.4
-      - docker tag traefik:2.4 ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-traefik:2.4
-      - docker push ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-traefik:2.4
-
-      # AWS CloudWatch agent (used to send statsd metrics)
-      - docker pull amazon/cloudwatch-agent
-      - docker tag amazon/cloudwatch-agent ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-aws-cloudwatch
-      - docker push ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-aws-cloudwatch
-
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/mirror-$BUILDKITE_BRANCH
-    concurrency: 1
-
-    plugins:
-      # First, assume the cross-account Docker build role
-      - cultureamp/aws-assume-role#aea2dc1ae6be19eec04de73518ef3f0070ae5f41:
-          role: arn:aws:iam::316981092358:role/BuildkiteRoleForImageBuilds
-
-      # Next, log in using the assumed role to the
-      - ecr#v2.3.0:
-          login: true
-          region: us-east-2
-          no-include-email: true
-
   # Wait on the above to to succeed before continuing
   - wait: ~
 
@@ -49,3 +22,37 @@ steps:
       WEBCMS_ENVIRONMENT: ${WEBCMS_ENVIRONMENT}
       WEBCMS_TF_MODULE: infrastructure
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/infrastructure
+
+  - wait: ~
+
+  # Copy images from the Docker Hub into the AWS perimeter
+  - label: ":docker: Mirror Images"
+    command:
+      # Traefik (used for routing behind the NLB)
+      - docker pull traefik:2.4
+      - docker tag traefik:2.4 ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-traefik:2.4
+      - docker push ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-traefik:2.4
+
+      # AWS CloudWatch agent (used to send statsd metrics)
+      - docker pull amazon/cloudwatch-agent
+      - docker tag amazon/cloudwatch-agent ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-aws-cloudwatch
+      - docker push ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-aws-cloudwatch
+
+      # New Relic PHP daemon (for APM)
+      - docker pull newrelic/php-daemon
+      - docker tag newrelic/php-daemon ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-newrelic-daemon
+      - docker push ${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-newrelic-daemon
+
+    concurrency_group: $BUILDKITE_PIPELINE_SLUG/mirror-$BUILDKITE_BRANCH
+    concurrency: 1
+
+    plugins:
+      # First, assume the cross-account Docker build role
+      - cultureamp/aws-assume-role#aea2dc1ae6be19eec04de73518ef3f0070ae5f41:
+          role: arn:aws:iam::316981092358:role/BuildkiteRoleForImageBuilds
+
+      # Next, log in using the assumed role to ECR
+      - ecr#v2.3.0:
+          login: true
+          region: us-east-2
+          no-include-email: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -391,6 +391,22 @@ copy:traefik:dev:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
 
+# Mirror the New Relic PHP daemon
+copy:newrelic:dev:
+  extends: .kaniko
+  stage: copy
+  only: [ci-work]
+
+  script:
+    - mkdir -p /workspace
+    - echo 'FROM newrelic/php-daemon' >/workspace/Dockerfile
+    - /kaniko/executor
+      --context=/workspace
+      --destination=$WEBCMS_REPO_URL/webcms-$WEBCMS_ENVIRONMENT-newrelic-daemon
+  variables:
+    WEBCMS_ENVIRONMENT: preproduction
+    WEBCMS_SITE: dev
+
 #endregion
 
 
@@ -548,13 +564,13 @@ deploy:dev:validate:en:
   only:
     refs:
       - ci-work
-  
+
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
     WEBCMS_LANG: en
     TF_STATE_NAME: dev-webcms-$WEBCMS_LANG
-    
+
   environment:
     name: site/dev-$WEBCMS_LANG
   script:

--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -50,6 +50,16 @@ FROM forumone/drupal8:7.3-xdebug AS dev
 
 # Development-only dependencies/config here
 
+# Download and install New Relic, but don't enable it. This allows us to use the extension
+# functions in our own code.
+ENV NEW_RELIC_AGENT_VERSION=9.17.1.301
+RUN set -ex \
+  && curl -L https://download.newrelic.com/php_agent/archive/${NEW_RELIC_AGENT_VERSION}/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-linux-musl.tar.gz | tar -C /tmp -zx \
+  && export NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 \
+  && /tmp/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-linux-musl/newrelic-install install \
+  && rm -rf /tmp/newrelic-php5-* /tmp/nrinstall* \
+  && echo newrelic.enabled=false >> $(php -r "echo(PHP_CONFIG_FILE_SCAN_DIR);")/newrelic.ini
+
 # Copy and enable the AWS Elasticache memcached extension
 COPY --from=memcached-ext \
   /usr/local/lib/php/extensions/no-debug-non-zts-20180731/memcached.so \
@@ -123,6 +133,16 @@ FROM forumone/drupal8:7.3 AS base
 
 # This is the base production layer. We use it here in order to make it easier to ensure
 # that both the dev and base targets are in sync with each other.
+
+# Download and install the New Relic APM extension. Note that, unlike in the docs, we do
+# not configure the extension here. That must happen at runtime since the license keys
+# and application names are environment-dependent.
+ENV NEW_RELIC_AGENT_VERSION=9.17.1.301
+RUN set -ex \
+  && curl -L https://download.newrelic.com/php_agent/archive/${NEW_RELIC_AGENT_VERSION}/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-linux-musl.tar.gz | tar -C /tmp -zx \
+  && export NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 \
+  && /tmp/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-linux-musl/newrelic-install install \
+  && rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
 
 # Copy and enable the AWS Elasticache memcached extension
 COPY --from=memcached-ext \
@@ -218,6 +238,12 @@ COPY web web
 COPY config config
 COPY drush drush
 
+# Add the entrypoint logic to configure the New Relic extension
+COPY scripts/ecs/drupal-entrypoint.sh /webcms-entrypoint
+RUN chmod +x /webcms-entrypoint
+
+ENTRYPOINT ["/webcms-entrypoint"]
+
 # Build an nginx container that has the same view into the Drupal filesystem
 # as well as its configuration file.
 FROM nginx:mainline-alpine AS nginx
@@ -234,6 +260,14 @@ COPY default.conf /etc/nginx/templates/default.conf.template
 # Build a drush-specific image: this image includes command-line utilities such as mysql
 # and ssh that are inappropriate for a server container image.
 FROM forumone/drupal8-cli:7.3 AS drush
+
+# Download and install New Relic
+ENV NEW_RELIC_AGENT_VERSION=9.17.1.301
+RUN set -ex \
+  && curl -L https://download.newrelic.com/php_agent/archive/${NEW_RELIC_AGENT_VERSION}/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-linux-musl.tar.gz | tar -C /tmp -zx \
+  && export NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 \
+  && /tmp/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-linux-musl/newrelic-install install \
+  && rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
 
 # Copy and enable the AWS Elasticache memcached extension
 COPY --from=memcached-ext \
@@ -260,3 +294,9 @@ COPY --from=drupal /var/www/html /var/www/html
 # Copy the migration script into /usr/local/bin as a command
 COPY scripts/ecs/drush-migrate.sh /usr/local/bin/drush-migrate
 RUN chmod +x /usr/local/bin/drush-migrate
+
+# Add the entrypoint logic to configure the New Relic extension
+COPY scripts/ecs/drupal-entrypoint.sh /webcms-entrypoint
+RUN chmod +x /webcms-entrypoint
+
+ENTRYPOINT ["/webcms-entrypoint"]

--- a/terraform/infrastructure/ecr.tf
+++ b/terraform/infrastructure/ecr.tf
@@ -61,6 +61,13 @@ resource "aws_ecr_repository" "traefik_mirror" {
   tags = var.tags
 }
 
+# This mirrors docker.io/newrelic/php-daemon
+resource "aws_ecr_repository" "newrelic_daemon_mirror" {
+  name = "webmcs-${var.environment}-newrelic-daemon"
+
+  tags = var.tags
+}
+
 # Finally, we create a cache repository for Kaniko-based builds. This repository has some
 # lifecycle policies that aggressively expire images in order to avoid an arbitrarily large
 # cache from building up (see below).

--- a/terraform/infrastructure/logging.tf
+++ b/terraform/infrastructure/logging.tf
@@ -43,6 +43,15 @@ resource "aws_cloudwatch_log_group" "agent" {
   tags = var.tags
 }
 
+# Log group for the New Relic PHP daemon
+resource "aws_cloudwatch_log_group" "newrelic" {
+  for_each = local.sites
+
+  name = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/newrelic-daemon"
+
+  tags = var.tags
+}
+
 # Log group for the FPM metrics helper
 resource "aws_cloudwatch_log_group" "fpm_metrics" {
   for_each = local.sites

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -162,6 +162,16 @@ resource "aws_ssm_parameter" "ecr_cloudwatch" {
   tags = var.tags
 }
 
+resource "aws_ssm_parameter" "ecr_newrelic" {
+  for_each = local.sites
+
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/ecr/newrelic-daemon"
+  type  = "String"
+  value = aws_ecr_repository.newrelic_daemon_mirror.repository_url
+
+  tags = var.tags
+}
+
 #endregion
 
 #region Log groups
@@ -206,6 +216,16 @@ resource "aws_ssm_parameter" "agent_log_group" {
   tags = var.tags
 }
 
+resource "aws_ssm_parameter" "newrelic_log_group" {
+  for_each = local.sites
+
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/log-groups/newrelic-daemon"
+  type  = "String"
+  value = aws_cloudwatch_log_group.newrelic[each.key].name
+
+  tags = var.tags
+}
+
 resource "aws_ssm_parameter" "fpm_metrics_log_group" {
   for_each = local.sites
 
@@ -225,7 +245,6 @@ resource "aws_ssm_parameter" "drupal_log_group" {
 
   tags = var.tags
 }
-
 
 #endregion
 
@@ -249,6 +268,16 @@ resource "aws_ssm_parameter" "db_d7_credentials" {
   value = aws_secretsmanager_secret.db_d7_credentials[each.key].arn
 
   tags = var.tags
+}
+
+resource "aws_ssm_parameter" "newrelic_license" {
+  for_each = local.sites
+
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.key}/secrets/newrelic-license"
+  type  = "String"
+  value = aws_secretsmanager_secret.newrelic_license[each.value.site].arn
+
+  tags  = var.tags
 }
 
 resource "aws_ssm_parameter" "hash_salt" {

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -277,7 +277,7 @@ resource "aws_ssm_parameter" "newrelic_license" {
   type  = "String"
   value = aws_secretsmanager_secret.newrelic_license[each.value.site].arn
 
-  tags  = var.tags
+  tags = var.tags
 }
 
 resource "aws_ssm_parameter" "hash_salt" {

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -273,7 +273,7 @@ resource "aws_ssm_parameter" "db_d7_credentials" {
 resource "aws_ssm_parameter" "newrelic_license" {
   for_each = local.sites
 
-  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.key}/secrets/newrelic-license"
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/secrets/newrelic-license"
   type  = "String"
   value = aws_secretsmanager_secret.newrelic_license[each.value.site].arn
 

--- a/terraform/infrastructure/secrets.tf
+++ b/terraform/infrastructure/secrets.tf
@@ -145,7 +145,9 @@ resource "aws_secretsmanager_secret" "newrelic_license" {
 # default. This value is ignored by Terraform when changed, but we need it to exist or
 # else ECS will fail to deploy it.
 resource "aws_secretsmanager_secret_version" "newrelic_license" {
-  secret_id = aws_secretsmanager_secret.newrelic_license.id
+  for_each = toset(var.sites)
+
+  secret_id = aws_secretsmanager_secret.newrelic_license[each.key].id
 
   secret_string = ""
 

--- a/terraform/infrastructure/secrets.tf
+++ b/terraform/infrastructure/secrets.tf
@@ -147,7 +147,7 @@ resource "aws_secretsmanager_secret" "newrelic_license" {
 resource "aws_secretsmanager_secret_version" "newrelic_license" {
   for_each = toset(var.sites)
 
-  secret_id = aws_secretsmanager_secret.newrelic_license[each.key].id
+  secret_id = aws_secretsmanager_secret.newrelic_license[each.value].id
 
   secret_string = ""
 

--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -172,7 +172,23 @@ resource "aws_ecs_task_definition" "drupal_task" {
           awslogs-stream-prefix = "fpm-metrics"
         }
       }
-    }
+    },
+
+    # Attach the New Relic PHP daemon
+    {
+      name = "newrelic"
+      image = "${data.aws_ssm_parameter.ecr_newrelic.value}:latest"
+
+      logConfiguration = {
+        logDriver = "awslogs"
+
+        options = {
+          awslogs-group         = data.aws_ssm_parameter.newrelic_log_group.value
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "newrelic"
+        }
+      }
+    },
   ])
 
   tags = var.tags

--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -176,7 +176,7 @@ resource "aws_ecs_task_definition" "drupal_task" {
 
     # Attach the New Relic PHP daemon
     {
-      name = "newrelic"
+      name  = "newrelic"
       image = "${data.aws_ssm_parameter.ecr_newrelic.value}:latest"
 
       logConfiguration = {

--- a/terraform/webcms/drush.tf
+++ b/terraform/webcms/drush.tf
@@ -44,7 +44,7 @@ resource "aws_ecs_task_definition" "drush_task" {
 
     # Attach the New Relic PHP daemon
     {
-      name = "newrelic"
+      name  = "newrelic"
       image = "${data.aws_ssm_parameter.ecr_newrelic.value}:latest"
 
       logConfiguration = {

--- a/terraform/webcms/drush.tf
+++ b/terraform/webcms/drush.tf
@@ -40,7 +40,23 @@ resource "aws_ecs_task_definition" "drush_task" {
           awslogs-stream-prefix = "drush"
         }
       }
-    }
+    },
+
+    # Attach the New Relic PHP daemon
+    {
+      name = "newrelic"
+      image = "${data.aws_ssm_parameter.ecr_newrelic.value}:latest"
+
+      logConfiguration = {
+        logDriver = "awslogs"
+
+        options = {
+          awslogs-group         = data.aws_ssm_parameter.newrelic_log_group.value
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "newrelic"
+        }
+      }
+    },
   ])
 
   tags = var.tags

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -94,6 +94,10 @@ data "aws_ssm_parameter" "ecr_cloudwatch" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/ecr/cloudwatch"
 }
 
+data "aws_ssm_parameter" "ecr_newrelic" {
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/ecr/newrelic-daemon"
+}
+
 #endregion
 
 #region Log groups
@@ -114,6 +118,10 @@ data "aws_ssm_parameter" "agent_log_group" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/log-groups/cloudwatch-agent"
 }
 
+data "aws_ssm_parameter" "newrelic_log_group" {
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/log-groups/newrelic-daemon"
+}
+
 data "aws_ssm_parameter" "fpm_metrics_log_group" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/log-groups/fpm-metrics"
 }
@@ -132,6 +140,10 @@ data "aws_ssm_parameter" "db_d8_credentials" {
 
 data "aws_ssm_parameter" "db_d7_credentials" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/secrets/db-d7-credentials"
+}
+
+data "aws_ssm_paramter" "newrelic_license" {
+  name = "/webcms/${var.environment}/${var.site}/${var.key}/secrets/newrelic-license"
 }
 
 data "aws_ssm_parameter" "hash_salt" {
@@ -176,6 +188,7 @@ locals {
     { name = "WEBCMS_AKAMAI_ACCESS_TOKEN", valueFrom = data.aws_ssm_parameter.akamai_access_token.value },
     { name = "WEBCMS_AKAMAI_CLIENT_TOKEN", valueFrom = data.aws_ssm_parameter.akamai_client_token.value },
     { name = "WEBCMS_AKAMAI_CLIENT_SECRET", valueFrom = data.aws_ssm_parameter.akamai_client_secret.value },
+    { name = "WEBCMS_NEW_RELIC_LICENSE", valueFrom = data.aws_ssm_parameter.newrelic_license.value },
   ]
 
   #endregion
@@ -223,6 +236,16 @@ locals {
     { name = "WEBCMS_SAML_IDP_SLO_URL", value = var.saml_idp_slo_url },
     { name = "WEBCMS_SAML_IDP_CERT", value = var.saml_idp_cert },
     { name = "WEBCMS_SAML_FORCE_SAML_LOGIN", value = var.saml_force_saml_login ? "1" : "0" },
+
+    # New Relic
+    {
+      # Construct two application names: the first is the "full" name (env/site/lang), and
+      # the second is a rollup name for the WebCMS env/site, which enables a view of the
+      # entire deployment across languages. This helps answer questions about how an
+      # entire codebase is performing in aggregate.
+      name = "WEBCMS_NEW_RELIC_APPNAME"
+      value = join(";", ["WebCMS ${var.environment}/${var.site}/${var.lang}", "WebCMS ${var.environment}/${var.site}"])
+    },
   ]
 
   #endregion

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -143,7 +143,7 @@ data "aws_ssm_parameter" "db_d7_credentials" {
 }
 
 data "aws_ssm_parameter" "newrelic_license" {
-  name = "/webcms/${var.environment}/${var.site}/${var.key}/secrets/newrelic-license"
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/secrets/newrelic-license"
 }
 
 data "aws_ssm_parameter" "hash_salt" {

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -142,7 +142,7 @@ data "aws_ssm_parameter" "db_d7_credentials" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/secrets/db-d7-credentials"
 }
 
-data "aws_ssm_paramter" "newrelic_license" {
+data "aws_ssm_parameter" "newrelic_license" {
   name = "/webcms/${var.environment}/${var.site}/${var.key}/secrets/newrelic-license"
 }
 

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -243,7 +243,7 @@ locals {
       # the second is a rollup name for the WebCMS env/site, which enables a view of the
       # entire deployment across languages. This helps answer questions about how an
       # entire codebase is performing in aggregate.
-      name = "WEBCMS_NEW_RELIC_APPNAME"
+      name  = "WEBCMS_NEW_RELIC_APPNAME"
       value = join(";", ["WebCMS ${var.environment}/${var.site}/${var.lang}", "WebCMS ${var.environment}/${var.site}"])
     },
   ]


### PR DESCRIPTION
This PR adds the infrastructure needed to monitor the WebCMS with New Relic. Specifically:

1. In the infrastructure Terraform:
   1. The New Relic PHP daemon is mirrored in ECR, much like Traefik and the CloudWatch agent.
   2. The daemon has a new log group created for it.
   3. A new Secrets Manager secret has been created for the license key. In order to avoid breaking existing deployments, a default value of `""` is deployed by Terraform. Changes to this value are ignored and Terraform won't revert them.
2. In the WebCMS Terraform:
   1. The New Relic daemon is available for both web-facing Drupal and command-line Drush workloads.
   2. A new startup scripts detects the presence of a New Relic license key in the environment and, if it is available, enables the extension.

When a New Relic license key is added to a site, the only administrative task needed is to stop all running ECS tasks corresponding to the service. ECS will spawn new tasks that will pick up the updated secret value, and New Relic should begin receiving data.