### PR TITLE
EPAD8-1175: Work around API requirements

### DIFF
--- a/services/drupal/scripts/ecs/drupal-entrypoint.sh
+++ b/services/drupal/scripts/ecs/drupal-entrypoint.sh
@@ -4,8 +4,8 @@ set -eu
 
 newrelic_ini_path="$(php -r "echo(PHP_CONFIG_FILE_SCAN_DIR);")/newrelic.ini"
 
-# If we have a license key and application name in this environment, configure New Relic.
-if test -n "${WEBCMS_NEW_RELIC_LICENSE:-}" && test -n "${WEBCMS_NEW_RELIC_APPNAME}"; then
+# If we have a non-default license key in this environment, configure New Relic.
+if test -n "${WEBCMS_NEW_RELIC_LICENSE:-}" && test "${WEBCMS_NEW_RELIC_LICENSE}" != .; then
   sed -i \
     -e "s/REPLACE_WITH_REAL_KEY/${WEBCMS_NEW_RELIC_LICENSE}/" \
     -e "s/newrelic.appname[[:space:]]=[[:space:]].*/newrelic.appname=\"${WEBCMS_NEW_RELIC_APPNAME}\"" \

--- a/terraform/infrastructure/secrets.tf
+++ b/terraform/infrastructure/secrets.tf
@@ -149,7 +149,7 @@ resource "aws_secretsmanager_secret_version" "newrelic_license" {
 
   secret_id = aws_secretsmanager_secret.newrelic_license[each.value].id
 
-  secret_string = ""
+  secret_string = "."
 
   lifecycle {
     ignore_changes = [secret_string, version_stages]


### PR DESCRIPTION
The AWS API documentation isn't particularly clear about whether or not empty strings are allowed, but Terraform is failing with an API error. I've changed the default value to the string `'.'` in order to unblock these failing deployments.