### PR TITLE
EPAD8-1175: Fix accidental removal of CMD

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -243,6 +243,7 @@ COPY scripts/ecs/drupal-entrypoint.sh /webcms-entrypoint
 RUN chmod +x /webcms-entrypoint
 
 ENTRYPOINT ["/webcms-entrypoint"]
+CMD [ "php-fpm" ]
 
 # Build an nginx container that has the same view into the Drupal filesystem
 # as well as its configuration file.

--- a/services/drupal/scripts/ecs/drupal-entrypoint.sh
+++ b/services/drupal/scripts/ecs/drupal-entrypoint.sh
@@ -10,9 +10,13 @@ if test -n "${WEBCMS_NEW_RELIC_LICENSE:-}" && test "${WEBCMS_NEW_RELIC_LICENSE}"
     -e "s/REPLACE_WITH_REAL_KEY/${WEBCMS_NEW_RELIC_LICENSE}/" \
     -e "s/newrelic.appname[[:space:]]=[[:space:]].*/newrelic.appname=\"${WEBCMS_NEW_RELIC_APPNAME}\"" \
     "$newrelic_ini_path"
+
+  status=enabled
 else
   # Otherwise, disable the extension.
   echo 'newrelic.enabled=false' >> "$newrelic_ini_path"
+
+  status=disabled
 fi
 
 {
@@ -21,6 +25,8 @@ fi
   echo 'newrelic.daemon.app_connect_timeout=15s'
   echo 'newrelic.daemon.start_timeout=5s'
 } >> "$newrelic_ini_path"
+
+echo "Status of New Relic in $newrelic_ini_path: $status"
 
 # Forward to the original image entrypoint
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
It appears that by setting an image's `ENTRYPOINT`, we remove the `CMD` we had been inheriting from our upstream image. This PR adds that in place, and also has more logging in the entrypoint in order to see how much progress we make before an exit.