### PR TITLE
EPAD8-1175: Use non-conflicting sed characters

### DIFF
--- a/services/drupal/scripts/ecs/drupal-entrypoint.sh
+++ b/services/drupal/scripts/ecs/drupal-entrypoint.sh
@@ -8,7 +8,7 @@ newrelic_ini_path="$(php -r "echo(PHP_CONFIG_FILE_SCAN_DIR);")/newrelic.ini"
 if test -n "${WEBCMS_NEW_RELIC_LICENSE:-}" && test "${WEBCMS_NEW_RELIC_LICENSE}" != .; then
   sed -i \
     -e "s/REPLACE_WITH_REAL_KEY/${WEBCMS_NEW_RELIC_LICENSE}/" \
-    -e "s/newrelic.appname[[:space:]]=[[:space:]].*/newrelic.appname=\"${WEBCMS_NEW_RELIC_APPNAME}\"" \
+    -e "s!newrelic.appname[[:space:]]=[[:space:]].*!newrelic.appname=\"${WEBCMS_NEW_RELIC_APPNAME}\"!" \
     "$newrelic_ini_path"
 
   status=enabled


### PR DESCRIPTION
Since we use `/` characters in the WebCMS application name, we need to use other delimiters in the sed expression that updates `newrelic.ini`.