### PR TITLE
Defer pushing CloudWatch logs until kernel terminate

### DIFF
--- a/infrastructure/terraform/iam.tf
+++ b/infrastructure/terraform/iam.tf
@@ -302,12 +302,14 @@ data "aws_iam_policy_document" "put_logs" {
   version = "2012-10-17"
 
   statement {
-    sid       = "allowPublishingLogEvents"
-    effect    = "Allow"
-    actions   = [
+    sid    = "allowPublishingLogEvents"
+    effect = "Allow"
+
+    actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ]
+
     resources = ["*"]
   }
 }

--- a/services/drupal/web/modules/custom/epa_cloudwatch/epa_cloudwatch.services.yml
+++ b/services/drupal/web/modules/custom/epa_cloudwatch/epa_cloudwatch.services.yml
@@ -4,3 +4,9 @@ services:
     arguments: ['@config.factory', '@logger.log_message_parser']
     tags:
       - { name: logger }
+
+  epa_cloudwatch.event_subscriber:
+    class: Drupal\epa_cloudwatch\EventSubscriber\LogFlushSubscriber
+    arguments: ['@logger.epa_cloudwatch']
+    tags:
+      - name: event_subscriber

--- a/services/drupal/web/modules/custom/epa_cloudwatch/src/EventSubscriber/LogFlushSubscriber.php
+++ b/services/drupal/web/modules/custom/epa_cloudwatch/src/EventSubscriber/LogFlushSubscriber.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\epa_cloudwatch\EventSubscriber;
+
+use Drupal\epa_cloudwatch\Logger\CloudWatch;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class LogFlushSubscriber implements EventSubscriberInterface {
+  /**
+   * @var \Drupal\epa_cloudwatch\Logger\CloudWatch
+   */
+  protected $logger;
+
+  public function __construct(CloudWatch $logger) {
+    $this->logger = $logger;
+  }
+
+  public function onConsoleTerminate(ConsoleTerminateEvent $event) {
+    $this->logger->flushLogEvents();
+  }
+
+  public function onKernelTerminate(TerminateEvent $event) {
+    $this->logger->flushLogEvents();
+  }
+
+  public static function getSubscribedEvents() {
+    return [
+      ConsoleEvents::TERMINATE => 'onConsoleTerminate',
+      KernelEvents::TERMINATE => 'onKernelTerminate',
+    ];
+  }
+}


### PR DESCRIPTION
This PR changes our logging logic so that the logger defers publishing log events until after the response has been sent to the client. We also listen for console exits to publish logs for Drush.