### PR TITLE
EPAD8-1322 auto width except for figure--video

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/_figure.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/_figure.scss
@@ -7,7 +7,7 @@
   max-width: 100%;
   position: relative;
   table-layout: fixed;
-  width: 100%;
+  width: auto;
 
   @include breakpoint(gesso-breakpoint(tablet)) {
     &.u-align-left,

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/figure--video/_figure--video.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/figure/figure--video/_figure--video.scss
@@ -3,6 +3,7 @@
 
 .figure--video {
   display: block;
+  width: 100%;
 
   .figure__caption {
     display: block;


### PR DESCRIPTION
Moved the width: 100% to the .figure--video variation instead of globally on the Figure component