### PR TITLE
[EPAD8-1238] Apply patch for aria-describedby in radios and checkboxes

### DIFF
--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -3959,7 +3959,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-3.6",
-                    "datestamp": "1620838181",
+                    "datestamp": "1623860918",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6636,6 +6636,10 @@
                     "name": "Lucas Hedding",
                     "homepage": "https://www.drupal.org/u/heddn",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "mikeryan",
+                    "homepage": "https://www.drupal.org/user/4420"
                 }
             ],
             "description": "Tools to assist in developing and running migrations.",
@@ -12049,7 +12053,8 @@
                 "nyholm/dsn": "^2.0.0",
                 "php": "^7.2 || ^8.0",
                 "psr/log": "^1.0",
-                "symfony/deprecation-contracts": "^2.2"
+                "symfony/deprecation-contracts": "^2.2",
+                "symfony/polyfill-php73": "^1.19"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "^3.155",
@@ -18726,5 +18731,5 @@
         "ext-pdo": "1.0.0",
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -30,7 +30,8 @@
       "Fix accessibility issues on inactive tabs": "https://www.drupal.org/files/issues/2021-04-19/2930508-48.patch",
       "Fix color contrast accessibility on vertical tabs": "https://www.drupal.org/files/issues/2021-06-16/3219165-3.patch",
       "Allow modules to alter EditorLinkDialog to specify link text": "https://www.drupal.org/files/issues/2020-09-11/2741945-85.patch",
-      "Display node title by default when creating link with drupalink, allow configuration.": "https://www.drupal.org/files/issues/2021-03-04/2961554-19.patch"
+      "Display node title by default when creating link with drupalink, allow configuration.": "https://www.drupal.org/files/issues/2021-03-04/2961554-19.patch",
+      "Fix aria-describedby in radios and checkboxes.": "https://www.drupal.org/files/issues/2020-09-08/2839344_0.patch"
     },
     "drupal/s3fs": {
       "Module should initialize default credentials provider instead of instance profile when use_instance_profile is TRUE": "https://www.drupal.org/files/issues/2020-03-24/3122091-2-s3fs-default-provider.patch",


### PR DESCRIPTION
Found a patch for the issue we were experiencing here https://www.drupal.org/project/drupal/issues/2839344

Currently fixed by the patch referenced in #17 within that link. Tested locally and the error for that aria attribute did not fire when tested, and appears to not exist when that element does not exist.