### PR TITLE
[EPAD8-1369] Enable the purge late runtime processor

### DIFF
--- a/services/drupal/config/sync/core.extension.yml
+++ b/services/drupal/config/sync/core.extension.yml
@@ -138,6 +138,7 @@ module:
   purge: 0
   purge_drush: 0
   purge_processor_cron: 0
+  purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_ui: 0
   rabbit_hole: 0


### PR DESCRIPTION
This PR enables the late runtime processor for purge. This will add an event subscriber for every "FINISH_REQUEST" kernel event that will grab a chunk of cache tags from the queue and send them to Akamai for invalidation. This event is the same event we're using for the EPA Cloudwatch module. Authenticated users should not see a noticeable slowdown of the site, but we should gain a lot of purge queue processing.