### PR TITLE
[EPAD8-1369] Enable the lateruntime processor

### DIFF
--- a/services/drupal/config/sync/purge.plugins.yml
+++ b/services/drupal/config/sync/purge.plugins.yml
@@ -12,7 +12,10 @@ processors:
     status: true
   -
     plugin_id: lateruntime
-    status: false
+    status: true
   -
     plugin_id: purge_ui_block_processor
+    status: true
+  -
+    plugin_id: cron
     status: true


### PR DESCRIPTION
This PR actually enables the late runtime purge processor, instead of only enabling the module. When I saved the config and exported, the change to enable the cron processor came along for the ride as well.﻿
