### PR TITLE
[EPAD8-1353] Adding additional step in logic to ensure we're on a ContentEntityInterface before moving further into the code.

### DIFF
--- a/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
+++ b/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
@@ -9,6 +9,7 @@ use Drupal\block\Entity\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
@@ -140,6 +141,7 @@ function epa_web_areas_field_widget_form_alter($element, FormStateInterface $for
   if (!empty($plugin_type)
       && $plugin_type == 'media_library_widget'
       && $form_state->getFormObject() instanceof EntityForm
+      && $form_state->getFormObject()->getEntity() instanceOf ContentEntityInterface
   ) {
     // Get group entity is associated with.
     // If the entity is unavailable, the group should be provided

--- a/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
+++ b/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
@@ -9,7 +9,6 @@ use Drupal\block\Entity\Block;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;


### PR DESCRIPTION
The `GroupContent::loadByEntity()` expects a `ContentEntityInterface`. Adding this additional check ensures the method gets what it expects, resolving the error we're seeing.

```
...
$entity = $form_state->getformObject()->getEntity();
if ($entity->id()) {
  $group_contents = GroupContent::loadByEntity($entity);
  foreach ($group_contents as $group_content) {
    $group = $group_content->getGroup();
  }
}
...
```