### PR TITLE
Buildkite CI updates

### DIFF
--- a/.buildkite/infrastructure.yml
+++ b/.buildkite/infrastructure.yml
@@ -15,9 +15,8 @@ steps:
   # This step has to wait for the VPC due to the dependency on networking component IDs
   # (subnets, security groups, and the VPC itself).
   - label: ":pipeline: :terraform: infrastructure"
-    if: build.branch == "main" && build.pull_request.id == null
-
     command: buildkite-agent pipeline upload .buildkite/terraform.apply.yml
+
     env:
       WEBCMS_ENVIRONMENT: ${WEBCMS_ENVIRONMENT}
       WEBCMS_TF_MODULE: infrastructure

--- a/.buildkite/infrastructure.yml
+++ b/.buildkite/infrastructure.yml
@@ -1,3 +1,7 @@
+env:
+  WEBCMS_ENVIRONMENT: ${WEBCMS_ENVIRONMENT?}
+  WEBCMS_IMAGE_TAG: ${WEBCMS_IMAGE_TAG?}
+
 steps:
   # Apply any pending updates to the VPC for this environment
   - label: ":pipeline: :terraform: network"

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -11,6 +11,12 @@
 #    images to deploy and thus wouldn't be able to continue safely.
 # 3. We use the terraform.apply.yml template to
 
+env:
+  WEBCMS_ENVIRONMENT: ${WEBCMS_ENVIRONMENT}
+  WEBCMS_SITE: ${WEBCMS_SITE}
+  WEBCMS_REPO_URL: ${WEBCMS_REPO_URL}
+  WEBCMS_IMAGE_TAG: ${WEBCMS_IMAGE_TAG}
+
 steps:
   - label: ":docker: Build images"
     command: bash .buildkite/build-images.sh
@@ -36,7 +42,6 @@ steps:
     env:
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/${WEBCMS_SITE}/en
       WEBCMS_TF_MODULE: webcms
-      WEBCMS_SITE: ${WEBCMS_SITE}
       WEBCMS_LANG: en
 
   - label: ":terraform: WebCMS (${WEBCMS_SITE}-es)"
@@ -45,25 +50,58 @@ steps:
     env:
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/${WEBCMS_SITE}/es
       WEBCMS_TF_MODULE: webcms
-      WEBCMS_SITE: ${WEBCMS_SITE}
       WEBCMS_LANG: es
 
   - wait: ~
 
   - label: ":ecs: Drush (${WEBCMS_SITE}-en)"
-    depends_on:
-      - terraform-${WEBCMS_SITE}-en
+    plugins:
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks
 
-    command: bash .buildkite/run-drush.sh
+      - docker#v3.8.0:
+          image: node:14-alpine
+          entrypoint: /bin/sh
+          command:
+            - -ec
+            - |
+              cd ci
+              npm ci
+              node drush.js
+
+          propagate-aws-auth-tokens: true
+          environment:
+            - AWS_REGION=us-east-2
+            - WEBCMS_ENVIRONMENT
+            - WEBCMS_SITE
+            - WEBCMS_LANG
+            - WEBCMS_IMAGE_TAG
+
     env:
-      WEBCMS_SITE: ${WEBCMS_SITE}
       WEBCMS_LANG: en
 
   - label: ":ecs: Drush (${WEBCMS_SITE}-es)"
-    depends_on:
-      - terraform-${WEBCMS_SITE}-es
+    plugins:
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks
 
-    command: bash .buildkite/run-drush.sh
+      - docker#v3.8.0:
+          image: node:14-alpine
+          entrypoint: /bin/sh
+          command:
+            - -ec
+            - |
+              cd ci
+              npm ci
+              node drush.js
+
+          propagate-aws-auth-tokens: true
+          environment:
+            - AWS_REGION=us-east-2
+            - WEBCMS_ENVIRONMENT
+            - WEBCMS_SITE
+            - WEBCMS_LANG
+            - WEBCMS_IMAGE_TAG
+
     env:
-      WEBCMS_SITE: ${WEBCMS_SITE}
-      WEBCMS_LANG: en
+      WEBCMS_LANG: es

--- a/terraform/infrastructure/rds.tf
+++ b/terraform/infrastructure/rds.tf
@@ -52,9 +52,9 @@ resource "aws_rds_cluster_parameter_group" "params" {
 
     apply_method = "pending-reboot"
   }
-  
+
   tags = var.tags
-  
+
 }
 
 resource "random_password" "rds_root_password" {
@@ -94,10 +94,10 @@ resource "aws_rds_cluster" "db" {
   tags = merge(
     var.tags,
     {
-      "cpm backup": "EPAWEB-Prod"
+      "cpm backup" : "EPAWEB-Prod"
     },
   )
-  
+
   # Ignore changes to the master password since it's stored in the Terraform state.
   # Instead, the value in Parameter Store should be treated as the sole source of truth.
   lifecycle {
@@ -116,11 +116,11 @@ resource "aws_rds_cluster_instance" "db_instance" {
 
   cluster_identifier   = aws_rds_cluster.db.cluster_identifier
   db_subnet_group_name = aws_rds_cluster.db.db_subnet_group_name
-  
+
   tags = merge(
     var.tags,
     {
-      "cpm backup": "EPAWEB-Prod"
+      "cpm backup" : "EPAWEB-Prod"
     },
   )
 }

--- a/terraform/infrastructure/s3.tf
+++ b/terraform/infrastructure/s3.tf
@@ -8,10 +8,10 @@ resource "aws_s3_bucket" "uploads" {
   versioning {
     enabled = true
   }
-  
+
   lifecycle_rule {
     enabled = true
-    
+
     noncurrent_version_expiration {
       days = 90
     }

--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -300,8 +300,8 @@ resource "aws_appautoscaling_scheduled_action" "after_hours" {
     min_capacity = var.drupal_min_capacity
     max_capacity = var.drupal_max_capacity
   }
-  
+
   depends_on = ["aws_appautoscaling_scheduled_action.business_hours"]
-  
+
 }
 


### PR DESCRIPTION
This PR introduces the changes necessary to allow Buildkite to deploy using the new Fargate-based infrastructure.

Note that the current Buildkite failure is expected; the Drupal deployment template is trying to read variables that haven't yet been written to AWS. This will be fixed on the first infrastructure deployment.