### PR TITLE
Update metatag.metatag_defaults.front.yml

### DIFF
--- a/services/drupal/config/sync/metatag.metatag_defaults.front.yml
+++ b/services/drupal/config/sync/metatag.metatag_defaults.front.yml
@@ -9,3 +9,12 @@ label: 'Front page'
 tags:
   canonical_url: '[site:url]'
   shortlink: '[site:url]'
+  title: '[site:name]'
+  og_image: /sites/all/themes/epa/img/epa-standard-og.jpg
+  og_image_alt: 'U.S. Environmental Protection Agency'
+  og_site_name: '[site:name]'
+  og_title: '[site:name]'
+  og_url: '[site:url]'
+  twitter_cards_image: /sites/all/themes/epa/img/epa-standard-twitter.jpg
+  twitter_cards_page_url: '[site:url]'
+  twitter_cards_title: '[site:name]'


### PR DESCRIPTION
https://forumone.atlassian.net/browse/EPAD8-1455

For some reason, the global defaults do not seem to apply to the front page, so we're adding these for the front page (in order to clear errors that FB and Twitter debuggers throw). I did not know how to generate a UUID for the Spanish version of metatag.metatag_defaults.front.yml