### PR TITLE
Update redirect_301.map

### DIFF
--- a/services/drupal/redirect_301.map
+++ b/services/drupal/redirect_301.map
@@ -196,7 +196,6 @@ map $request_uri $new_uri_301 {
     ~*^\/PR_Notices(\/|$).* /pesticide-registration/pesticide-registration-notices-year;
     ~*^\/products(\/|$).* /greenerproducts/$1;
     ~*^\/pugetsound(\/|$).* /puget-sound;
-    ~*^\/rcrarep(\/|$).*  https://cfext.epa.gov/rcrarep;
     ~*^\/read(\/|$).* https://ofmpub.epa.gov/sor_internet/registry/systmreg/;
     ~*^\/recyclecity(\/|$).* https://www3.epa.gov/recyclecity/$1;
     ~*^\/recycling(\/|$).* /recycle/$1;


### PR DESCRIPTION
We are removing the ~*^\/rcrarep(\/|$).*  https://cfext.epa.gov/rcrarep; redirect. We may add it back in after the office is done with some updates.