### PR TITLE
[EPAD8-1471] Updating patch to allow moving nodes between groups

### DIFF
--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -41,7 +41,7 @@
     },
     "drupal/group": {
       "Get a token of a node's parent group to create a pathauto pattern": "https://www.drupal.org/files/issues/2020-02-21/group-gnode_tokens-2774827-62.patch",
-      "Node update hook is triggered upon group content create": "https://www.drupal.org/files/issues/2019-09-13/group-2872697-33.patch",
+      "Node update hook is triggered upon group content create": "https://www.drupal.org/files/issues/2020-02-28/2872697-40-reroll-22.patch",
       "Fix user permissions on creating new content but not associating existing content": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch",
       "Set content moderation permissions on the groups level": "https://www.drupal.org/files/issues/2020-06-09/group-content_moderation-2906085-74.patch",
       "Ensure entity exists when deriving label": "https://www.drupal.org/files/issues/2020-03-03/group-3053524-14.patch",


### PR DESCRIPTION
Updating patch used to resolve issue when changing a node's group causes a resave of the entity causing a fatal duplicate key database error.