### PR TITLE
Update webform settings to allow UPPERCASE element keys

### DIFF
--- a/services/drupal/config/sync/webform.settings.yml
+++ b/services/drupal/config/sync/webform.settings.yml
@@ -126,7 +126,7 @@ form:
   filter_category: ''
   filter_state: ''
 element:
-  machine_name_pattern: a-z0-9_
+  machine_name_pattern: a-zA-Z0-9_
   empty_message: '{Empty}'
   allowed_tags: admin
   wrapper_classes: "container-inline clearfix\r\nform--inline clearfix\r\nmessages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"


### PR DESCRIPTION
Webforms needs to allow mixed letter casing at /admin/structure/webform/config/elements (see https://www.drupal.org/project/webform/issues/3153965) - Letters, numbers, and underscores