### PR TITLE
Update AU permission to allow viewing email address

### DIFF
--- a/services/drupal/config/sync/user.role.authenticated.yml
+++ b/services/drupal/config/sync/user.role.authenticated.yml
@@ -42,3 +42,4 @@ permissions:
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view the administration theme'
+  - 'view-user-email-addresses'


### PR DESCRIPTION
This permission introduced in Drupal 9.2.x