### PR TITLE
Add ALB to ECS cluster

### DIFF
--- a/services/drupal/status.conf
+++ b/services/drupal/status.conf
@@ -21,9 +21,7 @@ server {
   location = /ping {
     access_log off;
 
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    include fastcgi_params;
-    fastcgi_pass 127.0.0.1:9000;
+    return 200 "pong";
   }
 
   # The /status endpoint responds with some FPM metrics, available in a few formats (we

--- a/terraform/infrastructure/load_balancer.tf
+++ b/terraform/infrastructure/load_balancer.tf
@@ -6,7 +6,7 @@ resource "aws_lb" "load_balancer" {
   subnets            = local.public_subnets
 
   access_logs {
-    bucket  = aws_s3_bucket.elb_logs.bucket
+    bucket  = coalesce(var.lb_logging_bucket, aws_s3_bucket.elb_logs.bucket)
     enabled = true
   }
 
@@ -81,7 +81,7 @@ resource "aws_lb" "app_load_balancer" {
   security_groups = [data.aws_ssm_parameter.alb_security_group]
 
   access_logs {
-    bucket  = aws_s3_bucket.elb_logs.bucket
+    bucket  = coalesce(var.lb_logging_bucket, aws_s3_bucket.elb_logs.bucket)
     enabled = true
   }
 

--- a/terraform/infrastructure/load_balancer.tf
+++ b/terraform/infrastructure/load_balancer.tf
@@ -12,7 +12,7 @@ resource "aws_lb" "load_balancer" {
 
   tags = var.tags
 
-  # Explicitly depend on the S3 bucket policy that enables the ALB to deliver logs
+  # Explicitly depend on the S3 bucket policy that enables the NLB to deliver logs
   depends_on = [aws_s3_bucket_policy.elb_logs_delivery]
 }
 
@@ -31,11 +31,10 @@ resource "aws_lb_listener" "http" {
 resource "aws_lb_target_group" "http" {
   name = "webcms-${var.environment}-http"
 
-  port              = 80
-  protocol          = "TCP"
-  target_type       = "ip"
-  vpc_id            = data.aws_ssm_parameter.vpc_id.value
-  proxy_protocol_v2 = true
+  port        = 80
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = data.aws_ssm_parameter.vpc_id.value
 
   health_check {
     enabled  = true
@@ -49,9 +48,7 @@ resource "aws_lb_target_group" "http" {
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.load_balancer.arn
   port              = 443
-  protocol          = "TLS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = var.lb_default_certificate
+  protocol          = "TCP"
 
   default_action {
     type             = "forward"
@@ -59,21 +56,13 @@ resource "aws_lb_listener" "https" {
   }
 }
 
-resource "aws_lb_listener_certificate" "https" {
-  for_each = toset(var.lb_extra_certificates)
-
-  listener_arn    = aws_lb_listener.https.arn
-  certificate_arn = each.key
-}
-
 resource "aws_lb_target_group" "https" {
   name = "webcms-${var.environment}-https"
 
-  port              = 443
-  protocol          = "TCP"
-  target_type       = "ip"
-  vpc_id            = data.aws_ssm_parameter.vpc_id.value
-  proxy_protocol_v2 = true
+  port        = 443
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = data.aws_ssm_parameter.vpc_id.value
 
   health_check {
     enabled  = true
@@ -81,4 +70,87 @@ resource "aws_lb_target_group" "https" {
     port     = 443
     protocol = "TCP"
   }
+}
+
+resource "aws_lb" "app_load_balancer" {
+  name               = "webcms-${var.environment}-alb"
+  internal           = true
+  load_balancer_type = "application"
+
+  subnets         = local.public_subnets
+  security_groups = [data.aws_ssm_parameter.alb_security_group]
+
+  access_logs {
+    bucket  = aws_s3_bucket.elb_logs.bucket
+    enabled = true
+  }
+
+  tags = var.tags
+
+  # Explicitly depend on the S3 bucket policy that enables the ALB to deliver logs
+  depends_on = [aws_s3_bucket_policy.elb_logs_delivery]
+}
+
+resource "aws_lb_listener" "alb_health" {
+  load_balancer_arn = aws_lb.app_load_balancer.arn
+
+  port     = 8080
+  protocol = "HTTP"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      status_code  = 204
+    }
+  }
+}
+
+resource "aws_lb_target_group" "alb_http" {
+  name = "webcms-${var.environment}-alb-http"
+
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+
+  health_check {
+    enabled  = true
+    port     = 8080
+    protocol = "HTTP"
+    path     = "/ping"
+  }
+}
+
+resource "aws_lb_listener" "alb_http" {
+  load_balancer_arn = aws_lb.app_load_balancer.arn
+
+  port     = 80
+  protocol = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "alb_https" {
+  load_balancer_arn = aws_lb.app_load_balancer.arn
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = var.lb_default_certificate
+
+  port     = 443
+  protocol = "HTTPS"
+}
+
+resource "aws_lb_listener_certificate" "alb_https" {
+  for_each = toset(var.lb_extra_certificates)
+
+  listener_arn    = aws_lb_listener.alb_https.arn
+  certificate_arn = each.key
 }

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -18,6 +18,18 @@ resource "aws_ssm_parameter" "ecs_cluster_arn" {
 
 #endregion
 
+#region ALB
+
+resource "aws_ssm_parameter" "alb_listener" {
+  name  = "/webcms/${var.environment}/alb/listener"
+  type  = "String"
+  value = aws_lb_listener.alb_https.arn
+
+  tags = var.tags
+}
+
+#endregion
+
 #region Service endpoints
 
 resource "aws_ssm_parameter" "elasticache_endpoint" {
@@ -67,16 +79,6 @@ resource "aws_ssm_parameter" "cron_event_role" {
 #endregion
 
 #region Drupal-specific
-
-resource "aws_ssm_parameter" "drupal_listener" {
-  for_each = local.sites
-
-  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/drupal/listener"
-  type  = "String"
-  value = aws_lb_listener.alb_https.arn
-
-  tags = var.tags
-}
 
 resource "aws_ssm_parameter" "drupal_iam_task" {
   for_each = local.sites

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -68,6 +68,16 @@ resource "aws_ssm_parameter" "cron_event_role" {
 
 #region Drupal-specific
 
+resource "aws_ssm_parameter" "drupal_listener" {
+  for_each = local.sites
+
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/drupal/listener"
+  type  = "String"
+  value = aws_lb_listener.alb_https.arn
+
+  tags = var.tags
+}
+
 resource "aws_ssm_parameter" "drupal_iam_task" {
   for_each = local.sites
 

--- a/terraform/infrastructure/shared.tf
+++ b/terraform/infrastructure/shared.tf
@@ -54,6 +54,10 @@ data "aws_ssm_parameter" "drupal_security_group" {
   name = "/webcms/${var.environment}/security-groups/drupal"
 }
 
+data "aws_ssm_parameter" "alb_security_group" {
+  name = "/webcms/${var.environment}/security-groups/alb"
+}
+
 data "aws_ssm_parameter" "traefik_security_group" {
   name = "/webcms/${var.environment}/security-groups/traefik"
 }

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -47,6 +47,12 @@ variable "lb_extra_certificates" {
   default     = []
 }
 
+variable "lb_logging_bucket" {
+  description = "Use custom S3 logging bucket instead of the default managed one."
+  type        = string
+  default     = null
+}
+
 variable "lb_internal" {
   description = "Whether or not this environment's NLB is internal."
   type        = bool

--- a/terraform/network/README.md
+++ b/terraform/network/README.md
@@ -53,9 +53,10 @@ This module creates a number of security groups for the various resources in the
 
 - The Aurora cluster permits ingress from the RDS proxy and the Terraform startup task.
 - Elasticsearch, RDS proxy, and Elasticache permit ingress from Drupal tasks on their well-known ports (respectively: 443, 3306, and 11211).
-- The Drupal task permits ingress from the Traefik router service.
+- The Drupal task permits ingress from the Traefik router service and from the ALB. The ALB is allowed access on ports 443 and 8080, the latter of which is the health check port.
 - Drupal is permitted egress on ports 80 and 443, as well as outbound SMTP. This reference module uses port 587, but the actual port may differ in other environments.
 - The Traefik router permits ingress from public subnets. Since network load balancers don't support security groups, this is the best we can do.
+- The ALB allows unlimited public ingress. Since the ALB is fronted by an NLB, the NLB forwards the IP address of the client connection.
 
 ## Module Outputs
 
@@ -77,6 +78,7 @@ The parameters are stored under the Parameter Store path `/webcms/${var.environm
   - `/webcms/${var.environment}/security-groups/proxy`: ID of the RDS proxy security group
   - `/webcms/${var.environment}/security-groups/elasticsearch`: ID of the Elasticsearch security group
   - `/webcms/${var.environment}/security-groups/memcached`: ID of the ElastiCache security group
+  - `/webcms/${var.environment}/security-groups/alb`: ID of the ALB security group
   - `/webcms/${var.environment}/security-groups/drupal`: ID of the Drupal task security group
   - `/webcms/${var.environment}/security-groups/traefik`: ID of the Traefik router security group
   - `/webcms/${var.environment}/security-groups/terraform-database`: ID of the database intialization security group

--- a/terraform/network/parameters.tf
+++ b/terraform/network/parameters.tf
@@ -95,6 +95,14 @@ resource "aws_ssm_parameter" "traefik_security_group" {
   tags = var.tags
 }
 
+resource "aws_ssm_parameter" "alb_security_group" {
+  name  = "/webcms/${var.environment}/security-groups/alb"
+  type  = "String"
+  value = aws_security_group.alb.id
+
+  tags = var.tags
+}
+
 resource "aws_ssm_parameter" "terraform_database_security_group" {
   name  = "/webcms/${var.environment}/security-groups/terraform-database"
   type  = "String"

--- a/terraform/network/security.tf
+++ b/terraform/network/security.tf
@@ -44,6 +44,17 @@ resource "aws_security_group" "memcached" {
   })
 }
 
+resource "aws_security_group" "alb" {
+  name        = "webcms-${var.environment}-alb"
+  description = "Security group for the ALB"
+
+  vpc_id = aws_vpc.vpc.id
+
+  tags = merge(var.tags, {
+    Name = "WebCMS ALB (${var.environment})"
+  })
+}
+
 resource "aws_security_group" "traefik" {
   name        = "webcms-${var.environment}-traefik"
   description = "Security group for the Traefik reverse proxy"
@@ -143,6 +154,40 @@ resource "aws_security_group_rule" "terraform_database_egress" {
 
 #endregion
 
+#region ALB
+
+# Allow HTTP ingress to the ALB from arbitrary sources. Note that we don't limit
+# this to just the NLB's public subnets; in an AWS environment, the ALB's
+# security group rules apply not to the NLB's IP but the client IP.
+resource "aws_security_group_rule" "public_alb_http_ingress" {
+  description = "Allows HTTP ingress to the ALB"
+
+  security_group_id = aws_security_group.alb.id
+
+  type      = "ingres"
+  protocol  = "tcp"
+  from_port = 80
+  to_port   = 80
+
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+# Allow HTTPS ingress to the ALB from arbitrary sources.
+resource "aws_security_group_rule" "public_alb_https_ingress" {
+  description = "Allows HTTPS ingress to the ALB"
+
+  security_group_id = aws_security_group.alb.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+#endregion
+
 #region Traefik
 
 # Allow outbound HTTPS egress for Traefik. This is necessary in order to allow pulling
@@ -222,6 +267,60 @@ resource "aws_security_group_rule" "traefik_drupal_egress" {
   protocol  = "tcp"
   from_port = 443
   to_port   = 443
+
+  source_security_group_id = aws_security_group.drupal.id
+}
+
+# Allow traffic on port 443 from the ALB to Drupal
+resource "aws_security_group_rule" "drupal_alb_ingress" {
+  description = "Allows Drupal to receive traffic from the ALB"
+
+  security_group_id = aws_security_group.drupal.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  source_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_drupal_egress" {
+  description = "Allows the ALB to send traffic to Drupal"
+
+  security_group_id = aws_security_group.alb.id
+
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  source_security_group_id = aws_security_group.drupal.id
+}
+
+# Allow traffic on port 8080 from the ALB for health checks
+resource "aws_security_group_rule" "drupal_alb_health_ingress" {
+  description = "Allows Drupal to receive health check traffic from the ALB"
+
+  security_group_id = aws_security_group.drupal.id
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 8080
+  to_port   = 8080
+
+  source_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_drupal_health_egress" {
+  description = "Allows the ALB to send health check traffic to Drupal"
+
+  security_group_id = aws_security_group.alb.id
+
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 8080
+  to_port   = 8080
 
   source_security_group_id = aws_security_group.drupal.id
 }

--- a/terraform/network/security.tf
+++ b/terraform/network/security.tf
@@ -164,7 +164,7 @@ resource "aws_security_group_rule" "public_alb_http_ingress" {
 
   security_group_id = aws_security_group.alb.id
 
-  type      = "ingres"
+  type      = "ingress"
   protocol  = "tcp"
   from_port = 80
   to_port   = 80

--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -228,6 +228,13 @@ resource "aws_ecs_service" "drupal" {
     security_groups = [data.aws_ssm_parameter.drupal_security_group.value]
   }
 
+  # Identify this service with the load balancer's target group.
+  load_balancer {
+    target_group_arn = aws_lb_target_group.drupal.arn
+    container_name   = "nginx"
+    container_port   = 443
+  }
+
   # Ignore changes to the desired_count attribute - we assume that the application
   # autoscaling rules will take over after deployment.
   lifecycle {

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -26,6 +26,14 @@ data "aws_ssm_parameter" "ecs_cluster_arn" {
 
 #endregion
 
+#region ALB
+
+data "aws_ssm_parameter" "alb_listener" {
+  name = "/webcms/${var.environment}/alb/listener"
+}
+
+#endregion
+
 #region Service endpoints
 
 data "aws_ssm_parameter" "elasticache_endpoint" {
@@ -53,10 +61,6 @@ data "aws_ssm_parameter" "cron_event_role" {
 #endregion
 
 #region Drupal-specific
-
-data "aws_ssm_parameter" "drupal_listener" {
-  name = "/webcms/${var.environment}/${var.site}/${var.lang}/drupal/listener"
-}
 
 data "aws_ssm_parameter" "drupal_iam_task" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/drupal/iam-task"

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -54,6 +54,10 @@ data "aws_ssm_parameter" "cron_event_role" {
 
 #region Drupal-specific
 
+data "aws_ssm_parameter" "drupal_listener" {
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/drupal/listener"
+}
+
 data "aws_ssm_parameter" "drupal_iam_task" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/drupal/iam-task"
 }

--- a/terraform/webcms/target_group.tf
+++ b/terraform/webcms/target_group.tf
@@ -1,0 +1,31 @@
+# Create a target group for the Drupal service.
+resource "aws_lb_target_group" "drupal" {
+  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal"
+
+  port        = 443
+  protocol    = "HTTPS"
+  target_type = "ip"
+
+  health_check {
+    enabled  = true
+    port     = 8080
+    protocol = "HTTP"
+    path     = "/ping"
+  }
+}
+
+# Route requests for the Drupal hostnames to the target group.
+resource "aws_lb_listener_rule" "drupal" {
+  listener_arn = data.aws_ssm_parameter.drupal_listener.value
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.drupal.arn
+  }
+
+  condition {
+    host_header {
+      values = concat([var.drupal_hostname], var.drupal_extra_hostnames)
+    }
+  }
+}

--- a/terraform/webcms/target_group.tf
+++ b/terraform/webcms/target_group.tf
@@ -16,7 +16,7 @@ resource "aws_lb_target_group" "drupal" {
 
 # Route requests for the Drupal hostnames to the target group.
 resource "aws_lb_listener_rule" "drupal" {
-  listener_arn = data.aws_ssm_parameter.drupal_listener.value
+  listener_arn = data.aws_ssm_parameter.alb_listener.value
 
   action {
     type             = "forward"


### PR DESCRIPTION
This PR adds an ALB behind the existing NLB. This is the first half of the migration away from Traefik; the second will be done after the ALB is deployed in order to minimize disruption. There is a new VPC security group required for the ALB. Its requirements are documented in the `terraform/network` module, and it has implications on the existing Drupal VPC security group.