### PR TITLE
Infra webcms split

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -282,6 +282,10 @@ build:drupal:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
 
    # These correspond to the three production targets in services/drupal/Dockerfile. The
    # ordering here is important for builds with a limited pool of servers: by ensuring that
@@ -324,7 +328,10 @@ build:metrics:dev:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   script:
     - /kaniko/executor
       $KANIKO_CACHE_ARGS
@@ -342,7 +349,10 @@ build:database:dev:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   script:
     - /kaniko/executor
       $KANIKO_CACHE_ARGS
@@ -373,7 +383,10 @@ copy:cloudwatch:dev:
   stage: copy
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   script:
     - mkdir -p /workspace
     - echo 'FROM amazon/cloudwatch-agent' >/workspace/Dockerfile
@@ -391,6 +404,10 @@ build:traefik:dev:
   stage: infrastructure_preprod_build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   script:
     - /kaniko/executor
       $KANIKO_CACHE_ARGS
@@ -406,6 +423,10 @@ copy:newrelic:dev:
   stage: copy
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   script:
     - mkdir -p /workspace
     - echo 'FROM newrelic/php-daemon' >/workspace/Dockerfile
@@ -523,7 +544,10 @@ deploy:dev:init:en:
   stage: deploy:dev:init:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_LANG: en
     WEBCMS_ENVIRONMENT: preproduction
@@ -547,7 +571,10 @@ deploy:dev:init:es:
   stage: deploy:dev:init:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_LANG: es
     WEBCMS_ENVIRONMENT: preproduction
@@ -573,7 +600,10 @@ deploy:dev:validate:en:
   stage: deploy:dev:validate:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -591,6 +621,10 @@ deploy:dev:validate:es:
   stage: deploy:dev:validate:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -607,7 +641,10 @@ deploy:dev:plan-en:
   stage: deploy:dev:plan:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -638,7 +675,10 @@ deploy:dev:plan-es:
   stage: deploy:dev:plan:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -757,12 +797,12 @@ deploy:dev:apply-es:
   rules:
     - if: >-
         $TF_MODULE == "infrastructure" &&
-        ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live" || $CI_COMMIT_BRANCH == "ci-work")
+        ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
       when: manual
 
     - if: >-
         $TF_MODULE == "webcms" &&
-        ($CI_COMMIT_BRANCH == "integration" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live" || $CI_COMMIT_BRANCH == "ci-work")
+        ($CI_COMMIT_BRANCH == "integration" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
       when: on_success
 
     - when: never
@@ -924,7 +964,10 @@ update:dev:en:
   stage: update:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -942,7 +985,10 @@ update:dev:es:
   stage: update:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
+      when: never
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -431,6 +431,8 @@ infrastructure:preproduction:init:
   stage: infrastructure_preprod_init
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     TF_STATE_NAME: dev
@@ -444,6 +446,8 @@ infrastructure:preproduction:validate:
   stage: infrastructure_preprod_validate
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     TF_STATE_NAME: dev
@@ -457,6 +461,8 @@ infrastructure:preproduction:plan:
   stage: infrastructure_preprod_plan
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/infrastructure/**/*
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     TF_STATE_NAME: dev
@@ -477,7 +483,8 @@ infrastructure:preproduction:apply:
   stage: infrastructure_preprod_apply
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-
+      changes: 
+        - webcms/terraform/infrastructure/**/*
   dependencies: ["infrastructure:preproduction:plan"]
   variables:
     WEBCMS_ENVIRONMENT: preproduction

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -964,10 +964,10 @@ update:dev:en:
   stage: update:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -985,10 +985,10 @@ update:dev:es:
   stage: update:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -282,10 +282,10 @@ build:drupal:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
 
    # These correspond to the three production targets in services/drupal/Dockerfile. The
    # ordering here is important for builds with a limited pool of servers: by ensuring that
@@ -328,10 +328,10 @@ build:metrics:dev:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   script:
     - /kaniko/executor
       $KANIKO_CACHE_ARGS
@@ -349,10 +349,10 @@ build:database:dev:
   stage: build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   script:
     - /kaniko/executor
       $KANIKO_CACHE_ARGS
@@ -383,10 +383,10 @@ copy:cloudwatch:dev:
   stage: copy
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   script:
     - mkdir -p /workspace
     - echo 'FROM amazon/cloudwatch-agent' >/workspace/Dockerfile
@@ -404,10 +404,10 @@ build:traefik:dev:
   stage: infrastructure_preprod_build
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   script:
     - /kaniko/executor
       $KANIKO_CACHE_ARGS
@@ -423,10 +423,10 @@ copy:newrelic:dev:
   stage: copy
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   script:
     - mkdir -p /workspace
     - echo 'FROM newrelic/php-daemon' >/workspace/Dockerfile
@@ -544,10 +544,10 @@ deploy:dev:init:en:
   stage: deploy:dev:init:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_LANG: en
     WEBCMS_ENVIRONMENT: preproduction
@@ -571,10 +571,10 @@ deploy:dev:init:es:
   stage: deploy:dev:init:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_LANG: es
     WEBCMS_ENVIRONMENT: preproduction
@@ -600,10 +600,10 @@ deploy:dev:validate:en:
   stage: deploy:dev:validate:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -621,10 +621,10 @@ deploy:dev:validate:es:
   stage: deploy:dev:validate:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -641,10 +641,10 @@ deploy:dev:plan-en:
   stage: deploy:dev:plan:en
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -675,10 +675,10 @@ deploy:dev:plan-es:
   stage: deploy:dev:plan:es
   rules:
     - if: '$CI_COMMIT_BRANCH == "live"'
-    - if: '$CI_COMMIT_BRANCH == "live"'
       changes: 
-        - webcms/terraform/infrastructure/**/*
-      when: never
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
   variables:
     WEBCMS_ENVIRONMENT: preproduction
     WEBCMS_SITE: dev
@@ -710,7 +710,7 @@ deploy:dev:plan-es:
 deploy:dev:apply-en:
   extends: .deploy
   stage: deploy:dev:apply:en
-
+  
   # Download the plan files from the previous step.
   dependencies: ["deploy:dev:plan-en"]
 
@@ -747,12 +747,12 @@ deploy:dev:apply-en:
   rules:
     - if: >-
         $TF_MODULE == "infrastructure" &&
-        ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live" || $CI_COMMIT_BRANCH == "ci-work")
+        ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
       when: manual
 
     - if: >-
         $TF_MODULE == "webcms" &&
-        ($CI_COMMIT_BRANCH == "integration" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live" || $CI_COMMIT_BRANCH == "ci-work")
+        ($CI_COMMIT_BRANCH == "integration" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
       when: on_success
 
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -745,18 +745,13 @@ deploy:dev:apply-en:
   # NB. GitLab uses a "first match wins" order of rule evaluation, which is why the third
   # rule does not have an `if:` condition limiting when it applies.
   rules:
-    - if: >-
-        $TF_MODULE == "infrastructure" &&
-        ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
-      when: manual
-
-    - if: >-
-        $TF_MODULE == "webcms" &&
-        ($CI_COMMIT_BRANCH == "integration" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
-      when: on_success
-
-    - when: never
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
+      
+      
 deploy:dev:apply-es:
   extends: .deploy
   stage: deploy:dev:apply:es
@@ -795,18 +790,13 @@ deploy:dev:apply-es:
   # NB. GitLab uses a "first match wins" order of rule evaluation, which is why the third
   # rule does not have an `if:` condition limiting when it applies.
   rules:
-    - if: >-
-        $TF_MODULE == "infrastructure" &&
-        ($CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
-      when: manual
-
-    - if: >-
-        $TF_MODULE == "webcms" &&
-        ($CI_COMMIT_BRANCH == "integration" || $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "live")
-      when: on_success
-
-    - when: never
-
+    - if: '$CI_COMMIT_BRANCH == "live"'
+      changes: 
+        - webcms/terraform/webcms/**/*
+        - services/**/*
+      when: always
+      
+      
 #endregion
 
 


### PR DESCRIPTION
Lower priority than PHP update

This PR contains changes to the .gitlab-ci.yaml to enable the following:

These jobs will only be run when there are changes within the "webcms/terraform/infrastructure" directory:
infrastructure:preproduction:apply:
infrastructure:preproduction:plan:
infrastructure:preproduction:validate:
infrastructure:preproduction:init:

These jobs will only be run when there are changes within the "webcms/terraform/webcms" or "services/" directories:
update:dev:es:
update:dev:en:
deploy:dev:apply-es:
deploy:dev:apply-en:
deploy:dev:plan-es:
deploy:dev:plan-en:
deploy:dev:validate:es:
deploy:dev:validate:en:
deploy:dev:init:es:
deploy:dev:init:en:
copy:newrelic:dev:
build:traefik:dev:
copy:cloudwatch:dev:
build:database:dev:
build:metrics:dev:
build:drupal:


