### PR TITLE
No longer limiting artifacts to jobs with tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -948,18 +948,15 @@ update:dev:es:
   environment:
     name: site/dev-$WEBCMS_LANG
 
-###################
-# Create Releases #
-###################
+####################
+# Create Artifacts #
+####################
 
 # Create artifacts of ci, terraform/database, terraform/infrastructure, and terraform/webcms directories
-# Only run if CI_COMMIT_TAG is defined
 Artifacts:
   image: alpine
   stage: artifacts
   rules:
-    - if: $CI_COMMIT_TAG != ""
-      when: always
     - if: '$CI_COMMIT_BRANCH == "live"'
   script:
     - echo "Creating artifacts"


### PR DESCRIPTION
Since we still need to reference ECR images by commit SHA instead of by tag, it makes more sense to always create the artifacts to account for cases where we need to do prod terraform and CI updates independent of tagged releases