### PR TITLE
Update load_balancer.tf

### DIFF
--- a/terraform/infrastructure/load_balancer.tf
+++ b/terraform/infrastructure/load_balancer.tf
@@ -146,6 +146,11 @@ resource "aws_lb_listener" "alb_https" {
 
   port     = 443
   protocol = "HTTPS"
+  
+  default_action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.alb_http.arn
+  }
 }
 
 resource "aws_lb_listener_certificate" "alb_https" {


### PR DESCRIPTION
Hi Alex, we got the following error during the terraform validate step in the pipeline:

```
Error: Required attribute is not set
  on load_balancer.tf line 142, in resource "aws_lb_listener" "alb_https":
 142: resource "aws_lb_listener" "alb_https" {

```
It needed the default action block.  I believe I've got it correct in here, but please take a look and let me know if you see any issues.