### PR TITLE
Two changes to correct errors in the terraform apply step:

### DIFF
--- a/terraform/infrastructure/load_balancer.tf
+++ b/terraform/infrastructure/load_balancer.tf
@@ -109,7 +109,8 @@ resource "aws_lb_listener" "alb_health" {
 
 resource "aws_lb_target_group" "alb_http" {
   name = "webcms-${var.environment}-alb-http"
-
+  vpc_id      = data.aws_ssm_parameter.vpc_id.value
+  
   port        = 80
   protocol    = "HTTP"
   target_type = "ip"

--- a/terraform/infrastructure/load_balancer.tf
+++ b/terraform/infrastructure/load_balancer.tf
@@ -48,7 +48,7 @@ resource "aws_lb_target_group" "http" {
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.load_balancer.arn
   port              = 443
-  protocol          = "TCP"
+  protocol          = "HTTPS"
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
We saw the following two errors when trying to apply this terraform:

Error: Error modifying LB Listener: ValidationError: An SSL policy cannot be specifed for TCP listeners
	status code: 400, request id: eafb1313-d07b-4b1a-b761-27209e181d69
  on load_balancer.tf line 48, in resource "aws_lb_listener" "https":
  48: resource "aws_lb_listener" "https" {
Error: vpc_id should be set when target type is ip
  on load_balancer.tf line 110, in resource "aws_lb_target_group" "alb_http":
 110: resource "aws_lb_target_group" "alb_http" {

