### PR TITLE
EPAD8-1641: Admin info tweak

### DIFF
--- a/services/drupal/web/themes/epa_theme/templates/content/node--event--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--event--full.html.twig
@@ -15,7 +15,7 @@
 
 {% set display_sidenav = false %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% set display_sidenav = true %}
 {% endif %}
 
@@ -38,7 +38,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -48,7 +48,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/content/node--event--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--event--full.html.twig
@@ -36,6 +36,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -83,7 +89,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -96,7 +102,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--event--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--event--full.html.twig
@@ -36,12 +36,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -89,7 +83,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -102,7 +96,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--faq--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--faq--full.html.twig
@@ -15,7 +15,7 @@
 
 {% set display_sidenav = false %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% set display_sidenav = true %}
 {% endif %}
 
@@ -43,7 +43,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -53,7 +53,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/content/node--faq--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--faq--full.html.twig
@@ -41,12 +41,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -76,7 +70,7 @@
     'contact_link': contact_link,
     'title': content.field_question,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': content|without('epa_content_moderation_control', 'field_question'),
     'sidenav': sidenav,
     'footer': footer,
@@ -89,7 +83,7 @@
     'contact_link': contact_link,
     'title': content.field_question,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': content|without('epa_content_moderation_control', 'field_question'),
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--faq--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--faq--full.html.twig
@@ -41,6 +41,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -70,7 +76,7 @@
     'contact_link': contact_link,
     'title': content.field_question,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': content|without('epa_content_moderation_control', 'field_question'),
     'sidenav': sidenav,
     'footer': footer,
@@ -83,7 +89,7 @@
     'contact_link': contact_link,
     'title': content.field_question,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': content|without('epa_content_moderation_control', 'field_question'),
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--full.html.twig
@@ -15,7 +15,7 @@
 
 {% set display_sidenav = false %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% set display_sidenav = true %}
 {% endif %}
 
@@ -43,7 +43,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -53,7 +53,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/content/node--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--full.html.twig
@@ -41,6 +41,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -70,7 +76,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': content|without('epa_content_moderation_control'),
     'sidenav': sidenav,
     'footer': footer,
@@ -83,7 +89,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': content|without('epa_content_moderation_control'),
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--full.html.twig
@@ -41,12 +41,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -76,7 +70,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': content|without('epa_content_moderation_control'),
     'sidenav': sidenav,
     'footer': footer,
@@ -89,7 +83,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': content|without('epa_content_moderation_control'),
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--news-release--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--news-release--full.html.twig
@@ -39,6 +39,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -78,7 +84,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -91,7 +97,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--news-release--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--news-release--full.html.twig
@@ -39,12 +39,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -84,7 +78,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -97,7 +91,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--news-release--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--news-release--full.html.twig
@@ -41,7 +41,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -51,7 +51,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 
@@ -75,7 +75,7 @@
   ) }}
 {% endset %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% include '@templates/detail-pages/page-with-sidenav.twig' with {
     'has_header': true,
     'has_footer': has_footer,

--- a/services/drupal/web/themes/epa_theme/templates/content/node--perspective--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--perspective--full.html.twig
@@ -34,12 +34,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -69,7 +63,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': content|without('epa_content_moderation_control'),
     'sidenav': sidenav,
     'footer': footer,
@@ -82,7 +76,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': content|without('epa_content_moderation_control'),
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--perspective--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--perspective--full.html.twig
@@ -15,7 +15,7 @@
 
 {% set display_sidenav = false %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% set display_sidenav = true %}
 {% endif %}
 
@@ -36,7 +36,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -46,7 +46,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/content/node--perspective--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--perspective--full.html.twig
@@ -34,6 +34,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -63,7 +69,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': content|without('epa_content_moderation_control'),
     'sidenav': sidenav,
     'footer': footer,
@@ -76,7 +82,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': content|without('epa_content_moderation_control'),
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--public-notice--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--public-notice--full.html.twig
@@ -15,7 +15,7 @@
 
 {% set display_sidenav = false %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% set display_sidenav = true %}
 {% endif %}
 
@@ -38,7 +38,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -48,7 +48,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/content/node--public-notice--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--public-notice--full.html.twig
@@ -36,12 +36,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -101,7 +95,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -114,7 +108,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--public-notice--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--public-notice--full.html.twig
@@ -36,6 +36,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -95,7 +101,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -108,7 +114,7 @@
     'contact_link': contact_link,
     'title': title,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
@@ -15,7 +15,7 @@
 
 {% set display_sidenav = false %}
 
-{% if sidenav|render|striptags|trim %}
+{% if sidenav|render|striptags('<drupal-render-placeholder>')|trim %}
   {% set display_sidenav = true %}
 {% endif %}
 
@@ -38,7 +38,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -48,7 +48,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 
@@ -94,7 +94,7 @@
 {% endset %}
 
 {% set body %}
-  {% if box_content|striptags|trim %}
+  {% if box_content|striptags('<drupal-render-placeholder>')|trim %}
     {% include '@components/box/box.twig' with {
       'modifier_classes': 'box--related-info u-align-right',
       'title': {

--- a/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
@@ -36,12 +36,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -124,7 +118,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -137,7 +131,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': show_admin_info,
+    'show_admin_info': true,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
@@ -36,6 +36,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -118,7 +124,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'sidenav': sidenav,
     'footer': footer,
@@ -131,7 +137,7 @@
     'contact_link': contact_link,
     'title': label,
     'admin_info': admin_info,
-    'show_admin_info': true,
+    'show_admin_info': show_admin_info,
     'body': body,
     'footer': footer,
   } %}

--- a/services/drupal/web/themes/epa_theme/templates/content/node--web-area.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--web-area.html.twig
@@ -25,12 +25,6 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -68,7 +62,7 @@
   'contact_link': contact_link,
   'title': label,
   'admin': admin_info,
-  'show_admin_info': show_admin_info,
+  'show_admin_info': true,
   'slideshow': slideshow,
   'body': body,
   'footer': footer,

--- a/services/drupal/web/themes/epa_theme/templates/content/node--web-area.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--web-area.html.twig
@@ -27,7 +27,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 
@@ -37,7 +37,7 @@
 
 {% set has_footer = false %}
 
-{% if footer|render|striptags|trim %}
+{% if footer|striptags('<drupal-render-placeholder>')|trim %}
   {% set has_footer = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/content/node--web-area.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--web-area.html.twig
@@ -25,6 +25,12 @@
   {{ content.epa_content_moderation_control }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -62,7 +68,7 @@
   'contact_link': contact_link,
   'title': label,
   'admin': admin_info,
-  'show_admin_info': true,
+  'show_admin_info': show_admin_info,
   'slideshow': slideshow,
   'body': body,
   'footer': footer,

--- a/services/drupal/web/themes/epa_theme/templates/layout/region--messages.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/layout/region--messages.html.twig
@@ -5,6 +5,6 @@
  */
 #}
 
-<div class="js-toggle-admin-content">
+{% if logged_in %}<div class="js-toggle-admin-content">{% endif %}
   {{ content }}
-</div>
+{% if logged_in %}</div>{% endif %}

--- a/services/drupal/web/themes/epa_theme/templates/layout/region--messages.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/layout/region--messages.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ */
+#}
+
+<div class="js-toggle-admin-content">
+  {{ content }}
+</div>

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-faqs.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-faqs.html.twig
@@ -23,7 +23,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-faqs.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-faqs.html.twig
@@ -21,12 +21,6 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -74,7 +68,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': show_admin_info,
+  'show_admin_info': true,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-faqs.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-faqs.html.twig
@@ -21,6 +21,12 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -68,7 +74,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': true,
+  'show_admin_info': show_admin_info,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-news-releases.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-news-releases.html.twig
@@ -23,7 +23,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-news-releases.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-news-releases.html.twig
@@ -21,12 +21,6 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -79,7 +73,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': show_admin_info,
+  'show_admin_info': true,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-news-releases.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-news-releases.html.twig
@@ -21,6 +21,12 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -73,7 +79,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': true,
+  'show_admin_info': show_admin_info,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-perspectives.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-perspectives.html.twig
@@ -23,7 +23,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-perspectives.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-perspectives.html.twig
@@ -21,6 +21,12 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -71,7 +77,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': true,
+  'show_admin_info': show_admin_info,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-perspectives.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-perspectives.html.twig
@@ -21,12 +21,6 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -77,7 +71,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': show_admin_info,
+  'show_admin_info': true,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-public-notices.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-public-notices.html.twig
@@ -23,7 +23,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-public-notices.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-public-notices.html.twig
@@ -21,6 +21,12 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
+{% set show_admin_info = false %}
+
+{% if admin_info|striptags|trim %}
+  {% set show_admin_info = true %}
+{% endif %}
+
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -72,7 +78,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': true,
+  'show_admin_info': show_admin_info,
   'intro': intro,
   'search': search,
   'filters': filters,

--- a/services/drupal/web/themes/epa_theme/templates/views/views-view--search-public-notices.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/views/views-view--search-public-notices.html.twig
@@ -21,12 +21,6 @@
   {{ drupal_block('local_actions_block', wrapper=false) }}
 {% endset %}
 
-{% set show_admin_info = false %}
-
-{% if admin_info|render|striptags|trim %}
-  {% set show_admin_info = true %}
-{% endif %}
-
 {% set area_footer %}
   {{ drupal_entity('block', 'webareafooter', check_access=false) }}
 {% endset %}
@@ -78,7 +72,7 @@
   'title': view.title,
   'contextual_links': title_suffix.contextual_links,
   'admin_info': admin_info,
-  'show_admin_info': show_admin_info,
+  'show_admin_info': true,
   'intro': intro,
   'search': search,
   'filters': filters,


### PR DESCRIPTION
This PR undoes some of the work in #607 in favor of an approach that correctly checks if Twig variables have markup that should be output.