### PR TITLE
EPAD8-1659: Removing siteimprove from rendering in the admin bar

### DIFF
--- a/services/drupal/web/modules/custom/epa_core/epa_core.module
+++ b/services/drupal/web/modules/custom/epa_core/epa_core.module
@@ -610,6 +610,11 @@ function epa_core_module_implements_alter(&$implementations, $hook) {
   if ($hook === 'form_alter' && isset($implementations['group_content_menu'])) {
     unset($implementations['group_content_menu']);
   }
+
+  // Prevent siteimprove module from rendering into the admin bar.
+  if ($hook === 'toolbar' && isset($implementations['siteimprove'])) {
+    unset($implementations['siteimprove']);
+  }
 }
 
 /**


### PR DESCRIPTION
Things that have changed:
- [x] Preventing siteimprove from rendering on admin toolbar