### PR TITLE
EPAD8-1689: Disable X-Frame-Options for widgets

### DIFF
--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -98,6 +98,20 @@ server {
     proxy_pass http://$s3_base_path/$file_path;
   }
 
+  location ^~ /sites/default/files/widgets/ {
+    resolver 127.0.0.11 valid=30s;
+    resolver_timeout 5s;
+    expires 3600;
+
+     # S3 does *not* like http basic auth
+    proxy_set_header Authorization "";
+
+    # Allow embedding widgets on other domains
+    add_header X-Frame-Options "";
+
+    proxy_pass http://$WEBCMS_S3_DOMAIN/files/widgets/;
+  }
+
   location ^~ /sites/default/files/ {
     resolver 127.0.0.11 valid=30s;
     resolver_timeout 5s;


### PR DESCRIPTION
This PR disables the `X-Frame-Options` header for embedded widgets. Due to limitations in nginx's `if` directive, the cleanest solution is to create a new `location` block and use that to scope the disabling of the header.