### PR TITLE
EPAD8-1271: Quote matrix syntax

### DIFF
--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -52,7 +52,7 @@ steps:
 
   - label: ":ecs: Drush (${WEBCMS_SITE}-{{matrix}})"
     env:
-      WEBCMS_LANG: {{matrix}}
+      WEBCMS_LANG: '{{matrix}}'
 
     matrix:
       - en


### PR DESCRIPTION
This PR fixes a YAML syntax goof with the [Buildkite matrix](https://buildkite.com/docs/pipelines/build-matrix) in `.buildkite/webcms.yml`. Without the quotes, the `{{matrix}}` interpolation is treated as a dictionary of some kind.