### PR TITLE
EPAD8-1271: Build improvements

### DIFF
--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -89,7 +89,6 @@ steps:
                       --context=/workspace/services/metrics \
                       --destination="${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-fpm-metrics:${WEBCMS_IMAGE_TAG}"
 
-
   - wait: ~
 
   - label: ":terraform: WebCMS (${WEBCMS_SITE}-en)"
@@ -112,15 +111,8 @@ steps:
 
   - wait: ~
 
-  - label: ":ecs: Drush (${WEBCMS_SITE}-{{matrix}})"
-    env:
-      WEBCMS_LANG: '{{matrix}}'
-
-    matrix:
-      - en
-      - es
-
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/drush-$WEBCMS_SITE-{{matrix}}
+  - label: ":ecs: Drush (${WEBCMS_SITE}-en)"
+    concurrency_group: $BUILDKITE_PIPELINE_SLUG/drush-$WEBCMS_SITE-en
     concurrency: 1
 
     plugins:
@@ -142,8 +134,35 @@ steps:
             - AWS_REGION=us-east-2
             - WEBCMS_ENVIRONMENT
             - WEBCMS_SITE
-            - WEBCMS_LANG
+            - WEBCMS_LANG=en
             - WEBCMS_IMAGE_TAG
 
             # Propagate the BUILDKITE=true environment variable to tell the script to link to the logs
+            - BUILDKITE
+
+  - label: ":ecs: Drush (${WEBCMS_SITE}-es)"
+    concurrency_group: $BUILDKITE_PIPELINE_SLUG/drush-$WEBCMS_SITE-es
+    concurrency: 1
+
+    plugins:
+      - cultureamp/aws-assume-role#v0.1.0:
+          role: arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks
+
+      - docker#v3.8.0:
+          image: node:14-alpine
+          entrypoint: /bin/sh
+          command:
+            - -ec
+            - |
+              cd ci
+              npm ci
+              node drush.js
+
+          propagate-aws-auth-tokens: true
+          environment:
+            - AWS_REGION=us-east-2
+            - WEBCMS_ENVIRONMENT
+            - WEBCMS_SITE
+            - WEBCMS_LANG=es
+            - WEBCMS_IMAGE_TAG
             - BUILDKITE

--- a/ci/util.js
+++ b/ci/util.js
@@ -12,6 +12,11 @@ const ssm = require("./ssm");
 const vars = require("./vars");
 
 /**
+ * Base address of a link to the AWS console.
+ */
+const consoleUrl = `https://${vars.region}.console.aws.amazon.com`;
+
+/**
  * Amount of time, in milliseconds, to wait in between checking Drush's status in ECS.
  */
 const pollInterval = 5_000;
@@ -169,9 +174,7 @@ async function getLogsUrl(task) {
   );
 
   // Start with the region-specific AWS Console URL.
-  const url = new URL(
-    `https://${vars.region}.console.amazon.com/cloudwatch/home`
-  );
+  const url = new URL(`${consoleUrl}/cloudwatch/home`);
 
   // We also set the region via query parameters, to mimic the behavior of the console.
   url.searchParams.set("region", vars.region);
@@ -193,7 +196,7 @@ async function getTaskUrl(task) {
 
   // As above, start with the region-specific console URL and set the ?region query string
   // parameter.
-  const url = new URL(`https://${vars.region}.console.aws.amazon.com`);
+  const url = new URL(consoleUrl);
   url.searchParams.set("region", vars.region);
 
   // Construct the path to the task's landing page in the V2 ECS console (at the time of


### PR DESCRIPTION
This PR makes two changes:

1. It corrects the "Task logs" link to point directly to CloudWatch, and
2. It reverts the Buildkite matrix for Drush tasks in order to allow English and Spanish deployments to occur side-by-side.