### PR TITLE
EPAD8-1713: Create per-site EventBridge rules

### DIFF
--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -60,6 +60,27 @@ resource "aws_ssm_parameter" "elasticsearch_endpoint" {
 
 #region Cron
 
+resource "aws_ssm_parameter" "cron_event_rule_per_site" {
+  for_each = local.sites
+
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/cron/event-rule"
+  type  = "String"
+  value = aws_cloudwatch_event_rule.cron_per_site[each.value.site].name
+
+  tags = var.tags
+}
+
+resource "aws_ssm_parameter" "cron_event_role_per_site" {
+  for_each = local.sites
+
+  name = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/cron/event-role"
+  type = "String"
+  value = aws_iam_role.events.arn
+
+  tags = var.tags
+}
+
+# Keep the legacy parameters for compatibility with existing deployments
 resource "aws_ssm_parameter" "cron_event_rule" {
   name  = "/webcms/${var.environment}/cron/event-rule"
   type  = "String"

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -73,8 +73,8 @@ resource "aws_ssm_parameter" "cron_event_rule_per_site" {
 resource "aws_ssm_parameter" "cron_event_role_per_site" {
   for_each = local.sites
 
-  name = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/cron/event-role"
-  type = "String"
+  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/cron/event-role"
+  type  = "String"
   value = aws_iam_role.events.arn
 
   tags = var.tags

--- a/terraform/webcms/README.md
+++ b/terraform/webcms/README.md
@@ -186,6 +186,8 @@ As with the infrastructure and database modules, this module assumes that certai
 - From the ALB we need some ARNs:
   - `/webcms/${var.environment}/alb/listener`: The ARN of the ALB listener responsible for handling connections.
 - For Drupal, we load some identifiers for IAM, S3, and the ALB:
+  - `/webcms/${var.environment}/${var.site}/${var.lang}/cron/event-rule`: The name of the EventBridge rule governing cron invocations.
+  - `/webcms/${var.environment}/${var.site}/${var.lang}/cron/event-role`: The ARN of the EventBridge cron IAM role.
   - `/webcms/${var.environment}/${var.site}/${var.lang}/drupal/iam-task`: The ECS task role for Drupal and Drush. This is the run-time IAM role used by the WebCMS and has access to, e.g., S3 and Elasticssearch.
   - `/webcms/${var.environment}/${var.site}/${var.lang}/drupal/iam-execution`: The ECS execution role for Drupal and Drush. This role is used internally by Fargate to launch tasks and thus has access to ECR and Secrets Manager.
   - `/webcms/${var.environment}/${var.site}/${var.lang}/drupal/s3-bucket`: The name of the S3 bucket to store uploaded content.

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -55,11 +55,11 @@ data "aws_ssm_parameter" "elasticsearch_endpoint" {
 #region Cron
 
 data "aws_ssm_parameter" "cron_event_rule" {
-  name = "/webcms/${var.environment}/cron/event-rule"
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/cron/event-rule"
 }
 
 data "aws_ssm_parameter" "cron_event_role" {
-  name = "/webcms/${var.environment}/cron/event-role"
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/cron/event-role"
 }
 
 #endregion


### PR DESCRIPTION
This PR creates per-site EventBridge rules in order to support running more than two sites on the same environment. See the comments in the Terraform for more context.

**Deployment notes**: After this is merged, `EPAD8-1271` will need to be merged into `main` first in order to establish the new cron rules, and then we can merge down into `release` and `integration`.