### PR TITLE
EPAD8-1271: Fix plan concurrency

### DIFF
--- a/.buildkite/feature.yml
+++ b/.buildkite/feature.yml
@@ -140,12 +140,14 @@ steps:
     env:
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/network
       WEBCMS_TF_MODULE: network
+      WEBCMS_SITE: ''
 
   - label: ":pipeline: :terraform: infrastructure"
     command: buildkite-agent pipeline upload .buildkite/terraform.plan.yml
     env:
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/infrastructure
       WEBCMS_TF_MODULE: infrastructure
+      WEBCMS_SITE: ''
 
   # We arbitrarily choose English for a Terraform plan. The two sites' configurations
   # should not be so different that this will miss subtleties with Spanish-language

--- a/.buildkite/feature.yml
+++ b/.buildkite/feature.yml
@@ -137,6 +137,8 @@ steps:
 
   - label: ":pipeline: :terraform: network"
     commands:
+      # Prevent WEBCMS_SITE from creating multiple concurrency groups for this
+      # Terraform plan run.
       - unset WEBCMS_SITE
       - buildkite-agent pipeline upload .buildkite/terraform.plan.yml
     env:

--- a/.buildkite/feature.yml
+++ b/.buildkite/feature.yml
@@ -136,18 +136,20 @@ steps:
   # have only a minimal impact on build time.
 
   - label: ":pipeline: :terraform: network"
-    command: buildkite-agent pipeline upload .buildkite/terraform.plan.yml
+    commands:
+      - unset WEBCMS_SITE
+      - buildkite-agent pipeline upload .buildkite/terraform.plan.yml
     env:
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/network
       WEBCMS_TF_MODULE: network
-      WEBCMS_SITE: ''
 
   - label: ":pipeline: :terraform: infrastructure"
-    command: buildkite-agent pipeline upload .buildkite/terraform.plan.yml
+    commands:
+      - unset WEBCMS_SITE
+      - buildkite-agent pipeline upload .buildkite/terraform.plan.yml
     env:
       WEBCMS_SSM_NAMESPACE: /terraform/${WEBCMS_ENVIRONMENT}/infrastructure
       WEBCMS_TF_MODULE: infrastructure
-      WEBCMS_SITE: ''
 
   # We arbitrarily choose English for a Terraform plan. The two sites' configurations
   # should not be so different that this will miss subtleties with Spanish-language


### PR DESCRIPTION
This PR prevents the network and infrastructure plans from seeing the `$WEBCMS_SITE` variable in Buildkite. This was creating multiple concurrency groups for the same shared resource, resulting in Terraform potentially failing due to lock contention.