### PR TITLE
Fix missing OpenSSL dependency in image builds

### DIFF
--- a/.buildkite/feature.yml
+++ b/.buildkite/feature.yml
@@ -21,6 +21,10 @@ steps:
           - nginx
           - drush
 
+        # Use the more powerful Docker builder agent pool
+        agents:
+          queue: docker-builders
+
         # This concurrency group is shared with the fpm-metrics container build
         # below this step.
         concurrency_group: $BUILDKITE_PIPELINE_SLUG/build-$BUILDKITE_BRANCH

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -28,6 +28,9 @@ steps:
           - nginx
           - drush
 
+        agents:
+          queue: docker-builders
+
         concurrency_group: $BUILDKITE_PIPELINE_SLUG/build-$BUILDKITE_BRANCH
         concurrency: 4
 

--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -12,7 +12,7 @@ FROM forumone/drupal8:7.4 AS memcached-ext
 WORKDIR /
 
 # First, install the tools we need to build and link the two libraries.
-RUN apk add --no-cache $PHPIZE_DEPS git zlib-dev libevent-dev g++
+RUN apk add --no-cache $PHPIZE_DEPS git zlib-dev libevent-dev g++ openssl-dev
 
 # Second, clone and build AWS' libmemcached fork. Aside from the `sed' invocation (see
 # comment below), this hews to that repo's instructions.


### PR DESCRIPTION
This PR fixes image builds failing due to a missing `-lcrypto` dependency, causing these build errors:

```
checking whether compiling and linking against OpenSSL works... no
checking for CRYPTO_new_ex_data in -lcrypto... no
configure: error: OpenSSL libraries required
```

In addition, to avoid out-of-memory conditions in our default agent pool, this PR moves Docker image builds to the more powerful docker-builders pool.