### PR TITLE
EPAD8-1176: Allow building to new environments

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,9 @@ steps:
     if:
       build.branch != "integration" &&
       build.branch != "main" &&
-      build.branch != "release"
+      build.branch != "release" &&
+      build.branch != "live" &&
+      build.branch != "EPAD8-1705-USWDS-3"
 
     command: buildkite-agent pipeline upload .buildkite/feature.yml
     env:
@@ -42,17 +44,30 @@ steps:
   # is skipped, this wait incurs no penalty.
   - wait: ~
 
-  # For each of the three branches we deploy (integration, main, and release),
-  # run the webcms.yml pipeline.
+  # For each of the branches we deploy, run the webcms.yml pipeline. (See below
+  # for the USWDS environment.)
   - label: ":pipeline: WebCMS (${BUILDKITE_BRANCH})"
     if:
       build.pull_request.id == null && (
         build.branch == "integration" ||
         build.branch == "main" ||
-        build.branch == "release"
+        build.branch == "release" ||
+        build.branch == "live"
       )
 
     command: buildkite-agent pipeline upload .buildkite/webcms.yml
     env:
       WEBCMS_ENVIRONMENT: preproduction
       WEBCMS_SITE: ${BUILDKITE_BRANCH}
+
+  # The USWDS environment gets deployed from a branch where WEBCMS_SITE doesn't
+  # match up, so we handle it specially here.
+  - label: ":pipeline: WebCMS (uswds)"
+    if:
+      build.pull_request.id == null &&
+      build.branch == "EPAD8-1705-USWDS-3"
+
+    command: buildkite-agent pipeline upload .buildkite/webcms.yml
+    env:
+      WEBCMS_ENVIRONMENT: preproduction
+      WEBCMS_SITE: uswds


### PR DESCRIPTION
This PR adds Buildkite logic to deploy to the following new environments: `live` and `uswds`.