### PR TITLE
EPAD8-1854: Disable COPY caching for Kaniko

### DIFF
--- a/.buildkite/feature.yml
+++ b/.buildkite/feature.yml
@@ -62,9 +62,7 @@ steps:
               # 2. Kaniko build caching is enabled. Intermediate layers are
               #    pushed to a cache repository in ECR. Subsequent builds can
               #    query the cache instead of re-executing more expensive build
-              #    steps. We also cache COPY instructions, in order to
-              #    ameliorate the cost of copying /var/www/html for nginx and
-              #    drush.
+              #    steps.
               # 3. The snapshot mode is set to "redo" instead of "full". This
               #    uses cheaper but less accurate metadata for FS snapshots. We
               #    assume this won't cause any issues for us, as any changes in
@@ -91,7 +89,6 @@ steps:
                     /kaniko/executor \
                       --context=/workspace/services/drupal \
                       --cache \
-                      --cache-copy-layers \
                       --cache-repo="${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-cache" \
                       --skip-unused-stages \
                       --snapshotMode=redo \

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -61,7 +61,7 @@ steps:
                     /kaniko/executor \
                       --context=/workspace/services/drupal \
                       --cache \
-                      --cache-copy-layers \
+                      --cache-run-layers \
                       --cache-repo="${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-cache" \
                       --skip-unused-stages \
                       --snapshotMode=redo \

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -61,7 +61,6 @@ steps:
                     /kaniko/executor \
                       --context=/workspace/services/drupal \
                       --cache \
-                      --cache-run-layers \
                       --cache-repo="${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-cache" \
                       --skip-unused-stages \
                       --snapshotMode=redo \


### PR DESCRIPTION
Per GoogleContainerTools/kaniko#2227, new versions of Kaniko fail immediately upon detecting a multi-stage build with `COPY` layer caching. I haven't fully dug into the reasons why, but it appears that there are some fairly severe bugs lurking there, so we're better off removing the option.