### PR TITLE
[EPAD8-1857] - Hero Slideshow isn’t full-width when JS is disabled

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/utility-classes/_full-width.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/utility-classes/_full-width.scss
@@ -1,7 +1,8 @@
 // @file
 // Full-width utility class
 :root {
-  --scrollbar-width: 0;
+  /* stylelint-disable-next-line length-zero-no-unit */
+  --scrollbar-width: 0px;
 }
 
 .u-full-width {


### PR DESCRIPTION
when JS is diasbled, the hero slideshow is rendering incorrectly. this is because the scrollbar width is set to `0` instead of `0px`, which is required for any length properties using calc. there's a style lint exception added to bypass the "0 has no unit" rule since we need to have a unit.

notes on calc rule: [Mozilla Dev Docs for Calc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc)

> For lengths, you can't use 0 to mean 0px (or another length unit); instead, you must use the version with the unit: margin-top: calc(0px + 20px); is valid, while margin-top: calc(0 + 20px); is invalid.