### PR TITLE
EPAD8-1648: Prefers reduced motion

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/02-base/02-html-elements/00-universal/_universal.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/02-base/02-html-elements/00-universal/_universal.scss
@@ -11,7 +11,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * {
+  *,
+  *::before,
+  *::after {
     transition-duration: 0.01ms !important;
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/02-base/02-html-elements/00-universal/_universal.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/02-base/02-html-elements/00-universal/_universal.scss
@@ -10,6 +10,12 @@
   transition-timing-function: gesso-easing(ease-in);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 0.01ms !important;
+  }
+}
+
 @media print {
   * {
     background-color: transparent !important;

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/_index.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/_index.scss
@@ -10,6 +10,7 @@
 @forward 'hero/hero';
 @forward 'input/input';
 @forward 'modal/modal';
+@forward 'nav/nav';
 @forward 'section/section';
 @forward 'section/section--dark/section--dark';
 @forward 'site-alert/site-alert';

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/nav/_nav.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/nav/_nav.scss
@@ -1,0 +1,6 @@
+@media (prefers-reduced-motion: reduce) {
+  .usa-nav.is-visible {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/services/drupal/web/themes/epa_theme/source/_patterns/utility-classes/_accessibility.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/utility-classes/_accessibility.scss
@@ -29,12 +29,3 @@
 .u-invisible {
   @include invisible-important();
 }
-
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    scroll-behavior: auto !important;
-    transition-duration: 0.01ms !important;
-  }
-}

--- a/services/drupal/web/themes/epa_theme/source/_patterns/utility-classes/_accessibility.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/utility-classes/_accessibility.scss
@@ -29,3 +29,12 @@
 .u-invisible {
   @include invisible-important();
 }
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
This PR adds overrides for transition and animation when the browser is set to `prefers-reduced-motion`.

There appears to be only one `animation`, being set by a USWDS pattern on the nav. `.usa-nav.is-visible`. We set the media query for animation to be really quick, it's like there is no animation. We don't set animation to none because we need the final translate added to the nav element as set by the animation. 

There are multiple instances of `transition` being set on elements. While transitions can be accessible, it's safer to turn them off entirely. In the same way we handle animations, we transition so quick, it's like there was no transition at all. There are a handful of transitions being set on elements and in components. I could break the transition override out into the individual files. I chose not to because there is a transition set on all elements in `patterns/base/elements/universal/universal.scss` and in the button mixin, so a global override seemed appropriate. 

Additionally, it is recommended to set `background-attachment` to anything but `fixed` for those who prefer reduced motion. I did not find any instances of `background-attachement: fixed` being set but it's easy enough to add to this commit to prevent any future issues. 