### PR TITLE
Epad8 1873 no js slider first

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
@@ -35,9 +35,7 @@
     }
 
     &:not(:first-child) {
-      opacity: 0;
-      pointer-events: none;
-      visibility: hidden;
+      display: none;
     }
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
@@ -28,6 +28,17 @@
     grid-row: 1 / 2;
     position: relative !important;
   }
+
+  .no-js & {
+    &:first-child {
+      z-index: 1;
+    }
+
+    &:not(:first-child) {
+      opacity: 0;
+      visibility: hidden;
+    }
+  }
 }
 
 .hero-slideshow__nav {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
@@ -36,6 +36,7 @@
 
     &:not(:first-child) {
       opacity: 0;
+      pointer-events: none;
       visibility: hidden;
     }
   }


### PR DESCRIPTION
this PR sets the first slide in the slider to be stacked on top when javascript is turned off as it is currently showing the last slide due to the stacking order set by grid. 

this PR sets the first slide's z index to be on top. while that should be enough, to be sure, the other slides are set to not be displayed.