### PR TITLE
EPAD8-1900: Use correct parameter name

### DIFF
--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -159,7 +159,7 @@ data "aws_ssm_parameter" "newrelic_license" {
 }
 
 data "aws_ssm_parameter" "basic_auth" {
-  name = "/webcms/${var.environment}/${var.site}/${var.lang}/secrets/basic-authn"
+  name = "/webcms/${var.environment}/${var.site}/${var.lang}/secrets/basic-auth"
 }
 
 data "aws_ssm_parameter" "hash_salt" {


### PR DESCRIPTION
This PR corrects a typo in the parameter declaration in the WebCMS Terraform module.