### PR TITLE
EPAD8-1900: Grant access to the basic auth secret

### DIFF
--- a/terraform/infrastructure/drupal_iam_exec.tf
+++ b/terraform/infrastructure/drupal_iam_exec.tf
@@ -34,6 +34,7 @@ data "aws_iam_policy_document" "drupal_secrets_access" {
       aws_secretsmanager_secret.mail_pass[each.key].arn,
       aws_secretsmanager_secret.saml_sp_key[each.key].arn,
       aws_secretsmanager_secret.newrelic_license[each.value.site].arn,
+      aws_secretsmanager_secret.basic_auth[each.value.site].arn,
     ]
   }
 }


### PR DESCRIPTION
This PR addresses a missing `GetSecretValue` permission needed to pull the new basic auth secret.