### PR TITLE
EPAD8-1900: Inject secret into nginx

### DIFF
--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -80,6 +80,10 @@ resource "aws_ecs_task_definition" "drupal_task" {
         "traefik.http.services.${var.site}_${var.lang}.loadbalancer.server.port" = "443"
       }
 
+      secrets = [
+        { name = "WEBCMS_BASIC_AUTH", valueFrom = data.aws_ssm_parameter.basic_auth.value },
+      ]
+
       environment = [
         # See nginx.conf in services/drupal for why this is needed.
         { name = "WEBCMS_DOMAIN", value = var.drupal_hostname },

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -190,7 +190,6 @@ locals {
     { name = "WEBCMS_MAIL_PASS", valueFrom = data.aws_ssm_parameter.mail_pass.value },
     { name = "WEBCMS_SAML_SP_KEY", valueFrom = data.aws_ssm_parameter.saml_sp_key.value },
     { name = "WEBCMS_NEW_RELIC_LICENSE", valueFrom = data.aws_ssm_parameter.newrelic_license.value },
-    { name = "WEBCMS_BASIC_AUTH", valueFrom = data.aws_ssm_parameter.basic_auth.value },
   ]
 
   #endregion


### PR DESCRIPTION
This PR moves the WEBCMS_BASIC_AUTH environment variable into the nginx container instead of Drupal.