### PR TITLE
EPAD8-1899 - Fix Font Path in New Split Stylesheets

### DIFF
--- a/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
+++ b/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
@@ -62,7 +62,7 @@ image_gallery:
     - core/drupal
   css:
     theme:
-      css/image-gallery/image-gallery.css: {}    
+      css/image-gallery.css: {}    
 hero_slideshow:
   version: VERSION
   js:
@@ -72,7 +72,7 @@ hero_slideshow:
     - core/drupal
   css:
     theme:
-      css/hero-slideshow/hero-slideshow.css: {}  
+      css/hero-slideshow.css: {}  
 media_link:
   version: VERSION
   js:
@@ -102,99 +102,99 @@ audio:
   version: VERSION
   css:
     theme:
-      css/audio/audio.css: {}
+      css/audio.css: {}
 block:
   version: VERSION
   css:
     theme:
-      css/block/block.css: {}
+      css/block.css: {}
 boxes:
   version: VERSION
   css:
     theme:
-      css/box/index.css: {}      
+      css/box.css: {}      
 definition:
   version: VERSION
   css:
     theme:
-      css/definition/definition.css: {}         
+      css/definition.css: {}         
 document:
   version: VERSION
   css:
     theme:
-      css/document/document.css: {}
+      css/document.css: {}
 dropbutton:
   version: VERSION
   css:
     theme:
-      css/dropbutton/dropbutton.css: {}
+      css/dropbutton.css: {}
 facet:
   version: VERSION
   css:
     theme:
-      css/facet/facet.css: {}
+      css/facet.css: {}
 facet_list:
   version: VERSION
   css:
     theme:
-      css/facet-list/facet-list.css: {}
+      css/facet-list.css: {}
 field:
   version: VERSION
   css:
     theme:
-      css/field/index.css: {}      
+      css/field.css: {}      
 filters:
   version: VERSION
   css:
     theme:
-      css/filters/filters.css: {}
+      css/filters.css: {}
 header_link:
   version: VERSION
   css:
     theme:
-      css/header-link/header-link.css: {}  
+      css/header-link.css: {}  
 hero:
   version: VERSION
   css:
     theme:
-      css/hero/index.css: {}           
+      css/hero.css: {}           
 hublinks:
   version: VERSION
   css:
     theme:
-      css/hublinks/hublinks.css: {} 
+      css/hublinks.css: {} 
 pager:
   version: VERSION
   css:
     theme:
-      css/pager/pager.css: {}   
+      css/pager.css: {}   
 progress:
   version: VERSION
   css:
     theme:
-      css/progress/progress.css: {}   
+      css/progress.css: {}   
 rss_feed:
   version: VERSION
   css:
     theme:
-      css/rss-feed/rss-feed.css: {}    
+      css/rss-feed.css: {}    
 site_alert:
   version: VERSION
   css:
     theme:
-      css/site-alert/site-alert.css: {}
+      css/site-alert.css: {}
 teaser:
   version: VERSION
   css:
     theme:
-      css/teaser/teaser.css: {}
+      css/teaser.css: {}
 web_area_title:
   version: VERSION
   css:
     theme:
-      css/web-area-title/web-area-title.css: {}
+      css/web-area-title.css: {}
 web_area_footer:
   version: VERSION
   css:
     theme:
-      css/web-area-footer/web-area-footer.css: {}                                                                       
+      css/web-area-footer.css: {}                                                                       

--- a/services/drupal/web/themes/epa_theme/gulpfile.js
+++ b/services/drupal/web/themes/epa_theme/gulpfile.js
@@ -106,6 +106,14 @@ const buildSass = mode => {
         }),
       ])
     )
+    .pipe(rename(function (path) {
+      if(path.basename === 'index') {
+        path.basename = path.dirname;
+      }
+      if(path.dirname != '.') {
+        path.dirname = '.';
+      }
+    }))
     .pipe(sourcemaps.write('.'))
     .pipe(dest('css'));
 };


### PR DESCRIPTION
This PR fixes the font path error in the new component stylesheets.

Currently the font paths are incorrect in the new split stylesheets because the stylesheets are nested in individual component folders. The font path is set in `config.design-tokens.yml` to go only up one folder `line 9: font-path: '../fonts'`, causing the fonts in nested folders to error.

The fonts are generally loading correctly due to the core stylesheet being in the right location for the fonts to be linked properly. However, we should still fix the loading error! 

We do this by editing the gulpfile. When buildSass runs, we check to see if our directory name is anything other than '.' (our base). If it does have a directory name, we replace it with '.'

Additionally, some of the split stylesheets were named "index" because they're rendering off of an index file containing multiple component variants. The gulp rename function will now also check if the files' name is index, and if it is, the file will be renamed to the folder name. The folder name is unique to each component, therefore the stylesheets outputted names are also unique. This runs before we replace any directories with the base.

I've also updated all the links to the stylesheet in `epa_theme.libraries.yml` to their new non-nested location. 