### PR TITLE
EPAD8-1736 add to calendar button styling

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/00-cms-styles/addtocal/_addtocal.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/00-cms-styles/addtocal/_addtocal.scss
@@ -1,15 +1,28 @@
 // @file
 // Styles for the Add to Cal module.
+@use 'usa-button' as *;
 
 .addtocal-container {
   .addtocal {
+    @extend .usa-button;
+    margin-right: 0;
+
     + div {
       left: auto !important;
+      min-width: 159px;
       right: 0;
     }
   }
 
   .form-item__label {
+    font-size: 1rem;
+    margin: 0;
+    padding: 3px;
+    text-align: center;
     white-space: nowrap;
+
+    &::before {
+      content: none;
+    }
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/00-cms-styles/addtocal/_addtocal.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/00-cms-styles/addtocal/_addtocal.scss
@@ -3,6 +3,8 @@
 @use 'usa-button' as *;
 
 .addtocal-container {
+  float: right;
+
   .addtocal {
     @extend .usa-button;
     margin-right: 0;

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/00-cms-styles/addtocal/_addtocal.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/00-cms-styles/addtocal/_addtocal.scss
@@ -1,9 +1,17 @@
 // @file
 // Styles for the Add to Cal module.
 @use 'usa-button' as *;
+@use '../../../00-config' as *;
 
 .addtocal-container {
-  float: right;
+  float: none;
+  margin-bottom: 12px;
+  margin-top: 12px;
+
+  @include breakpoint(gesso-breakpoint(mobile-lg)) {
+    float: right;
+    margin-top: 0;
+  }
 
   .addtocal {
     @extend .usa-button;

--- a/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/event.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/event.twig
@@ -27,16 +27,29 @@
         },
     ],
   } %}
-  {% include '@components/field/field.twig' with {
-    'label': 'Add to Calendar',
-    'label_element': 'h2',
-    'element': 'div',
-    'field_items': [
-        {
-          'content': '<ul><li><a href="#">iCalendar</a></li><li><a href="#">Outlook</a></li><li><a href="#">Google</a></li><li><a href="#">Yahoo</a></li></ul>',
-        },
-    ],
-  } %}
+
+  <div class="addtocal-container">
+    {% include '@components/button/button.twig' with {
+      'text': 'Add to Calendar',
+      'modifier_classes': 'addtocal',
+    } %}
+    <div class="form-item form-item--radios">
+      <div class="form-item form-item--radio form-item--id-type">
+        <input class="addtocal-menu form-item__radio" type="radio" id="edit-type-generic" name="type" value="generic">  
+        <label for="edit-type-generic" class="form-item__label is-after">iCal / Outlook</label>
+      </div>
+
+      <div class="form-item form-item--radio form-item--id-type">
+        <input class="addtocal-menu form-item__radio" type="radio" id="edit-type-google" name="type" value="google">
+        <label for="edit-type-google" class="form-item__label is-after">Google</label>
+      </div>
+
+      <div class="form-item form-item--radio form-item--id-type">
+        <input class="addtocal-menu form-item__radio" type="radio" id="edit-type-yahoo" name="type" value="yahoo">
+        <label for="edit-type-yahoo" class="form-item__label is-after">Yahoo!</label>
+      </div>
+    </div>
+  </div>  
   {% include '@components/field/field.twig' with {
     'label': 'Registration Deadline',
     'label_element': 'h3',

--- a/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/event.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/event.twig
@@ -33,23 +33,8 @@
       'text': 'Add to Calendar',
       'modifier_classes': 'addtocal',
     } %}
-    <div class="form-item form-item--radios">
-      <div class="form-item form-item--radio form-item--id-type">
-        <input class="addtocal-menu form-item__radio" type="radio" id="edit-type-generic" name="type" value="generic">  
-        <label for="edit-type-generic" class="form-item__label is-after">iCal / Outlook</label>
-      </div>
-
-      <div class="form-item form-item--radio form-item--id-type">
-        <input class="addtocal-menu form-item__radio" type="radio" id="edit-type-google" name="type" value="google">
-        <label for="edit-type-google" class="form-item__label is-after">Google</label>
-      </div>
-
-      <div class="form-item form-item--radio form-item--id-type">
-        <input class="addtocal-menu form-item__radio" type="radio" id="edit-type-yahoo" name="type" value="yahoo">
-        <label for="edit-type-yahoo" class="form-item__label is-after">Yahoo!</label>
-      </div>
-    </div>
   </div>  
+  
   {% include '@components/field/field.twig' with {
     'label': 'Registration Deadline',
     'label_element': 'h3',


### PR DESCRIPTION
This PR styles the "add to calendar" button and dropdown on event pages. 

The "add to calendar" button is now using the default USWDS button styling. The dropdown has been styled to match the width of the button, remove the large radio circles, to have slightly smaller centered text, and less padding all around. 

