### PR TITLE
Epad8 1904 definitions in claro try 2

### DIFF
--- a/services/drupal/web/themes/epa_claro/css/styles.css
+++ b/services/drupal/web/themes/epa_claro/css/styles.css
@@ -32,3 +32,7 @@
   font-size: 1.266rem;
   margin-top: 1em;
 }
+
+#definition_pane {
+  white-space: normal;
+}

--- a/services/drupal/web/themes/epa_claro/epa_claro.info.yml
+++ b/services/drupal/web/themes/epa_claro/epa_claro.info.yml
@@ -106,7 +106,7 @@ libraries-extend:
     - claro/ckeditor-editor
   ckeditor/drupal.ckeditor.admin:
     - claro/ckeditor-admin
-  core/ckeditor:
+  ckeditor/ckeditor:
     - claro/ckeditor-dialog
   core/drupal.collapse:
     - claro/details-focus


### PR DESCRIPTION
This PR wraps the definition text when adding a dictionary term.

The issue is caused by CSS reset that is occuring in editor.css
`/modules/contrib/ckeditor/vendor/skins/moono-lisa/editor.css`
`.cke_reset_all * {white-space: nowrap;}`

It's setting all content in the CKE editor to have no white space wrapping. Thus when there is really long text, it'll stretch the parent box causing the issue reported.

This PR fixes the problem for just the definition on a dictionary term, but this could be happening on other items. I clicked into numerous different options set in the editor and did not find any other examples. That doesn't mean it's not happening though!