### PR TITLE
EPAD8-1840 Change Internal Link Text

### DIFF
--- a/services/drupal/web/themes/epa_theme/js/src/protected-links.es6.js
+++ b/services/drupal/web/themes/epa_theme/js/src/protected-links.es6.js
@@ -29,7 +29,7 @@ import Drupal from 'drupal';
 
       externalLinks.forEach(function(el) {
         if (el.hasAttribute('href') && linkIsProtected(el)) {
-          const translatedAccessible = Drupal.t('Link to protected area');
+          const translatedAccessible = Drupal.t('Exit to EPA’s internal site');
           el.insertAdjacentHTML(
             'beforeend',
             `<svg class="icon icon--exit is-spaced-before" role="img"><title>${translatedAccessible}</title><use href="/themes/epa_theme/images/sprite.svg#lock"></use></svg>`


### PR DESCRIPTION
this PR changes the label that appears on external links that feature the "lock icon" from `Link to protected area` to `Exit to EPA’s internal site`. Confirmed it's rendering on pattern lab. 