### PR TITLE
EPAD8-1805 Latest Revision Background Color

### DIFF
--- a/services/drupal/web/modules/custom/epa_workflow/css/revision-list.css
+++ b/services/drupal/web/modules/custom/epa_workflow/css/revision-list.css
@@ -23,3 +23,7 @@
 #edit-node-revisions-table .dropbutton .dropbutton-action > * {
   white-space: normal;
 }
+
+#edit-node-revisions-table tr.revision-latest:not(.revision-current) td {
+	background-color: #faf3d1;
+}

--- a/services/drupal/web/modules/custom/epa_workflow/css/revision-list.css
+++ b/services/drupal/web/modules/custom/epa_workflow/css/revision-list.css
@@ -25,5 +25,5 @@
 }
 
 #edit-node-revisions-table tr.revision-latest:not(.revision-current) td {
-	background-color: #faf3d1;
+  background-color: #faf3d1;
 }


### PR DESCRIPTION
the PR highlights the latest revision in the revisions tab with a light yellow background color. 
the selector is set to work on `.revision-latest:not(.revision-current)`. 

I added the content in the CSS file for the EPA Workflow module. I tested to confirm the background color is rendering in Claro and Seven theme. 