### PR TITLE
EPAD8-1903 EPA Claro color contrast improvement for layout builder

### DIFF
--- a/services/drupal/web/themes/epa_claro/css/styles.css
+++ b/services/drupal/web/themes/epa_claro/css/styles.css
@@ -32,3 +32,15 @@
   font-size: 1.266rem;
   margin-top: 1em;
 }
+
+#drupal-off-canvas .inline-block-list {
+  margin-left: 0;
+}
+
+#drupal-off-canvas .inline-block-list li {
+  list-style-type: none;
+}
+
+#drupal-off-canvas .inline-block-list li a {
+  color: #ffffff;
+}


### PR DESCRIPTION
this issue is caused by the jquery ui theme.css setting any links under .ui-widget-content to be #333 and the layout builder .css setting the background color on list items links to have a background color of #444.

this PR sets the link color to white and lightly updates the styling of the list items.

#fff / #444 passes color contrast requirements.

<img width="735" alt="Screen Shot 2022-12-05 at 11 19 36 PM" src="https://user-images.githubusercontent.com/26546908/205837093-7cd1a659-1e15-4a5c-807f-38825dfc9a0b.png">
