### PR TITLE
Allowfor0drushpods

### DIFF
--- a/terraform/webcms/drush.tf
+++ b/terraform/webcms/drush.tf
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "drush_task" {
 resource "aws_ecs_service" "drush" {
   name            = "webcms-${var.environment}-${var.site}-${var.lang}-drush"
   cluster         = data.aws_ssm_parameter.ecs_cluster_arn.value
-  desired_count   = 1
+  desired_count   = var.drush_tasks
   task_definition = aws_ecs_task_definition.drush_task.arn
 
   launch_type      = "FARGATE"

--- a/terraform/webcms/variables.tf
+++ b/terraform/webcms/variables.tf
@@ -94,6 +94,16 @@ variable "drupal_csrf_origin_whitelist" {
 
 #endregion
 
+#region Drush service Configuration
+
+variable "drush_tasks" {
+  description = "The number of drush tasks to implement per site.  There will be a default value of 1.  The intent is to only have to specify this if you want something other than the default 1 task."
+  type        = number
+  default     = 1
+}
+
+#end region
+
 #region Email
 
 variable "email_auth_user" {


### PR DESCRIPTION
Making two changes that allow us to set the number of drush tasks to 0 if desired.  Adds a default value of "1" to the drush tasks variable to make the variable optional