### PR TITLE
EPAD8-1612 Media Grid Library Checkboxes are Cut Off

### DIFF
--- a/services/drupal/web/themes/epa_seven/css/base/elements.css
+++ b/services/drupal/web/themes/epa_seven/css/base/elements.css
@@ -40,3 +40,18 @@
 .views-exposed-form .form--inline .form-item .field-suffix {
   display: block;
 }
+
+.media-library-item--grid .media-library-item__attributes {
+  bottom: auto;
+  left: 35px;
+  max-width: calc(100% - 53px);
+}
+
+.media-library-item--grid .views-field-field-banner-image-restricted {
+  bottom: 50px;
+  font-weight: bold;
+  left: 10px;
+  position: absolute;
+  right: 10px;
+  text-align: center;
+}


### PR DESCRIPTION
This PR adds a little bit of CSS to update the styling for the Media Grid view in Seven theme. 
This also lightly styles the required text, which I believe will also happen in EPA-1946. Will update that PR as well. 