### PR TITLE
EPAD8-1972: Remove margin-0 class from paragraph blocks

### DIFF
--- a/services/drupal/web/themes/epa_theme/templates/block/block--paragraph.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/block/block--paragraph.html.twig
@@ -4,4 +4,23 @@
  * Theme override for a paragraph block.
  */
 #}
-{% extends "block--admin.html.twig" %}
+{% set block_content %}
+  {% block block_content %}
+    {{ content }}
+  {% endblock %}
+{% endset %}
+
+{% embed '@components/block/block.twig' with {
+  'hide_wrapper': not logged_in,
+  'has_constrain': false,
+  'title_prefix': title_prefix,
+  'label': label,
+  'title_suffix': title_suffix,
+  'hide_content_wrapper': true,
+} %}
+
+  {% block content %}
+    {{ block_content }}
+  {% endblock %}
+
+{% endembed %}


### PR DESCRIPTION
This update removes the class `margin-0` from paragraph blocks.  This prevents the possibility of block titles and paragraph content sitting flush with the previous paragraph block above it. 

This issue was reported happening in the Layout Builder tool. 

Note: 
This ticket is labeled for `Fast Track`, which means this PR is into `main` instead of `release`. 

View: 
https://integration.epa.byf1.dev/node/280302/latest

JIRA:
https://forumone.atlassian.net/browse/EPAD8-1972