### PR TITLE
EPAD8-2020: Convert division / to math.div in all sass partials

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/00-config/01-mixins/_mixins.aspect-ratio.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/00-config/01-mixins/_mixins.aspect-ratio.scss
@@ -1,8 +1,10 @@
 // @file
 // Aspect Ratio mixin
 
+@use "sass:math";
+
 @mixin aspect-ratio($width, $height) {
   height: 0;
-  padding-top: ($height / $width) * 100%;
+  padding-top: (math.div($height, $width)) * 100%;
   width: 100%;
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/00-config/01-mixins/_mixins.grids.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/00-config/01-mixins/_mixins.grids.scss
@@ -39,8 +39,8 @@
 ) {
   display: flex;
   flex-wrap: wrap;
-  margin-left: rem(math.div($gutter-width, 2));
-  margin-right: rem(math.div($gutter-width, 2));
+  margin-left: rem(math.div(-$gutter-width, 2));
+  margin-right: rem(math.div(-$gutter-width, 2));
 
   > * {
     @include set-flex-column($columns, $gutter-width, $item-min-width);

--- a/services/drupal/web/themes/epa_theme/source/_patterns/00-config/01-mixins/_mixins.grids.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/00-config/01-mixins/_mixins.grids.scss
@@ -2,6 +2,7 @@
 // Flex Grid mixins
 
 @use '../00-functions' as *;
+@use "sass:math";
 
 // Set flex column width.
 // @param {Number} $columns Number of columns. 1 or 0 result in a single column.
@@ -12,14 +13,14 @@
   $gutter-width: gesso-get-map(gutter-width),
   $item-min-width: false
 ) {
-  $column-percentage: if($columns > 0, percentage(1 / $columns), 100%);
+  $column-percentage: if($columns > 0, percentage(math.div(1, $columns)), 100%);
 
   flex-basis: auto;
   flex-grow: 0;
   flex-shrink: 0;
   margin-bottom: rem($gutter-width);
-  margin-left: rem($gutter-width / 2);
-  margin-right: rem($gutter-width / 2);
+  margin-left: rem(math.div($gutter-width, 2));
+  margin-right: rem(math.div($gutter-width, 2));
   width: calc(#{$column-percentage} - #{rem($gutter-width)});
 
   @if $item-min-width {
@@ -38,8 +39,8 @@
 ) {
   display: flex;
   flex-wrap: wrap;
-  margin-left: rem(-$gutter-width / 2);
-  margin-right: rem(-$gutter-width / 2);
+  margin-left: rem(math.div($gutter-width, 2));
+  margin-right: rem(math.div($gutter-width, 2));
 
   > * {
     @include set-flex-column($columns, $gutter-width, $item-min-width);


### PR DESCRIPTION
Per a discussion yesterday we have decided to leave the Tiny Slider style updates as is, which continues to prevent the division depreciation warnings.  This update targets the use of `/` for division and replaces it with `math.div` in SASS partials. The following files were updated:
- _mixins.aspect-ratio.scss
- _mixins.grid.scss

I have browsed the website in general to ensure the grid was not effected negatively and have verified that the aspect-ratio works as expected. 

This is a Fast Track update and the PR has been made into `main`. 

View:
https://integration.epa.byf1.dev/
https://integration.epa.byf1.dev/node/280300/latest (Video embed uses the updated aspect-ratio updates)

JIRA:
https://forumone.atlassian.net/browse/EPAD8-2020