### PR TITLE
Epad8 2024 editorally tweaks

### DIFF
--- a/services/drupal/config/sync/editoria11y.settings.yml
+++ b/services/drupal/config/sync/editoria11y.settings.yml
@@ -4,7 +4,7 @@ content_root: .article
 assertiveness: smart
 no_load: ''
 ignore_all_if_absent: ''
-ignore_elements: '.js-toggle-admin-content *, .footer, .l-header, .addtocal-container'
+ignore_elements: '.js-toggle-admin-content *, .footer, .l-header, .addtocal-container, . addtocal'
 embedded_content_warning: ''
 download_links: ''
 ignore_link_strings: ''

--- a/services/drupal/config/sync/editoria11y.settings.yml
+++ b/services/drupal/config/sync/editoria11y.settings.yml
@@ -4,7 +4,7 @@ content_root: .article
 assertiveness: smart
 no_load: ''
 ignore_all_if_absent: ''
-ignore_elements: '.js-toggle-admin-content *, .footer, .l-header'
+ignore_elements: '.js-toggle-admin-content *, .footer, .l-header, .addtocal-container'
 embedded_content_warning: ''
 download_links: ''
 ignore_link_strings: ''

--- a/services/drupal/config/sync/editoria11y.settings.yml
+++ b/services/drupal/config/sync/editoria11y.settings.yml
@@ -4,7 +4,7 @@ content_root: .article
 assertiveness: smart
 no_load: ''
 ignore_all_if_absent: ''
-ignore_elements: '.js-toggle-admin-content *, .footer, .l-header, .addtocal-container, . addtocal'
+ignore_elements: '.js-toggle-admin-content *, .footer, .l-header, .addtocal-container *, .addtocal *'
 embedded_content_warning: ''
 download_links: ''
 ignore_link_strings: ''

--- a/services/drupal/config/sync/user.role.beta_tester.yml
+++ b/services/drupal/config/sync/user.role.beta_tester.yml
@@ -1,9 +1,14 @@
 uuid: bb04e05b-a23b-4909-b304-19f136098885
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - editoria11y
 id: beta_tester
 label: 'Beta Tester'
 weight: 0
 is_admin: null
-permissions: {  }
+permissions:
+  - 'mark as hidden in editoria11y'
+  - 'mark as ok in editoria11y'
+  - 'view editoria11y checker'

--- a/services/drupal/config/sync/user.role.system_webmaster.yml
+++ b/services/drupal/config/sync/user.role.system_webmaster.yml
@@ -20,7 +20,6 @@ dependencies:
     - block
     - block_content_permissions
     - content_moderation
-    - editoria11y
     - entity_usage
     - epa_core
     - epa_media
@@ -89,8 +88,6 @@ permissions:
   - 'edit paragraph library item'
   - 'execute node_assign_owner_action node'
   - 'export news releases'
-  - 'mark as hidden in editoria11y'
-  - 'mark as ok in editoria11y'
   - 'permit news releases'
   - 'permit perspectives'
   - 'reassign group content'
@@ -116,7 +113,6 @@ permissions:
   - 'use text format full_html'
   - 'view all media revisions'
   - 'view any unpublished content'
-  - 'view editoria11y checker'
   - 'view latest version'
   - 'view paragraphs library listing'
   - 'view the administration theme'


### PR DESCRIPTION
This PR:

- ignored the add to cal module and any children links
- removes the editorially module from role "webmaster"
- adds the editoria11y module to the role "beta tester" with 3 of 5 permissions.