### PR TITLE
EPAD8-2011 add usa intro styling into stylesheets

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/core.scss
+++ b/services/drupal/web/themes/epa_theme/source/core.scss
@@ -34,6 +34,7 @@
 @forward 'usa-icon-list';
 @forward 'usa-icon';
 @forward 'usa-identifier';
+@forward 'usa-intro';
 @forward 'usa-layout-docs';
 @forward 'usa-layout-grid';
 @forward 'usa-media-block';

--- a/services/drupal/web/themes/epa_theme/source/styles.scss
+++ b/services/drupal/web/themes/epa_theme/source/styles.scss
@@ -34,6 +34,7 @@
 @forward 'usa-icon-list';
 @forward 'usa-icon';
 @forward 'usa-identifier';
+@forward 'usa-intro';
 @forward 'usa-layout-docs';
 @forward 'usa-layout-grid';
 @forward 'usa-media-block';

--- a/services/drupal/web/themes/epa_theme/source/wysiwyg.scss
+++ b/services/drupal/web/themes/epa_theme/source/wysiwyg.scss
@@ -34,6 +34,7 @@
 @forward 'usa-icon-list';
 @forward 'usa-icon';
 @forward 'usa-identifier';
+@forward 'usa-intro';
 @forward 'usa-layout-docs';
 @forward 'usa-layout-grid';
 @forward 'usa-media-block';


### PR DESCRIPTION
This PR brings the styling for 'uswds intro' into all stylesheets that import uswds. (styles.scss, core.scss, wysiwyg.scss). 

