### PR TITLE
EPAD8-2041: Update page title and link to parent web area

### DIFF
--- a/services/drupal/web/themes/epa_theme/includes/field.inc
+++ b/services/drupal/web/themes/epa_theme/includes/field.inc
@@ -29,4 +29,17 @@ function epa_theme_preprocess_field(&$variables) {
       ]);
     }
   }
+
+  if ($element['#bundle'] == 'speeches' && $element['#field_name'] == 'field_related_information') {
+    $node = $element['#object'];
+    foreach ($node->entitygroupfield as $group) {
+      array_unshift($variables['items'], [
+        'content' => [
+          '#type' => 'link',
+          '#title' => 'Read more EPA Speeches and Remarks',
+          '#url' => $group->entity->getGroup()->field_homepage->entity->toUrl(),
+        ],
+      ]);
+    }
+  }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/speeches-remarks.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/speeches-remarks.twig
@@ -1,7 +1,6 @@
 {% set header_info %}
-  {% include '@components/hublinks/hublinks.twig' with {
-    'title': 'Related Topics'|t,
-    'links': links,
+  {% include '@components/web-area-title/web-area-title.twig' with {
+    'text': 'Speeches and Remarks',
   } %}
 {% endset %}
 
@@ -24,7 +23,7 @@
         'tag': 'div',
         'text': 'Related Information',
       },
-      'content': '<ul><li><a href="#watch">Watch the Event</a></li><li><a href="#0">Read the September 2022 news release</a></li><li><a href="#0">Learn about Environmental Justice</a></li><li><a href="#0">Learn about External Civil Rights</a></li></ul>',
+      'content': '<ul><li><a href="#watch">Watch the Event</a></li><li><a href="#0">Read more EPA Speeches and Remarks</a></li><li><a href="#0">Read the September 2022 news release</a></li><li><a href="#0">Learn about Environmental Justice</a></li><li><a href="#0">Learn about External Civil Rights</a></li></ul>',
     } only %}
   </div>
   <h2>Administrator Michael Regan</h2>

--- a/services/drupal/web/themes/epa_theme/templates/content/node--speeches--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--speeches--full.html.twig
@@ -20,16 +20,9 @@
 {% endif %}
 
 {% set header_info %}
-  {% if nav_style == 'sidebar_navigation' %}
-    {% if node.field_wide_template.value %}
-      {% set display_sidenav = false %}
-      {{ node.entitygroupfield|view({type: 'group_homepage_node_formatter', settings: {link: true,shortname: true}}) }}
-    {% else %}
-      {{ node.entitygroupfield|view({type: 'group_homepage_node_formatter', settings: {link: false,shortname: true}}) }}
-    {% endif %}
-  {% else %}
-    {{ node.field_hublinks|view({type: 'web_areas_homepage_link_formatter', settings: {}}) }}
-  {% endif %}
+  {% include '@components/web-area-title/web-area-title.twig' with {
+    'text': 'Speeches and Remarks'|t,
+  } %}
 {% endset %}
 
 {% set contact_link %}
@@ -71,6 +64,7 @@
     {% if content.field_video|field_value %}
       <li><a href="#watch">Watch the Event</a></li>
     {% endif %}
+    {{ speeches_more }}
     {{ content.field_related_information }}
   </ul>
 {% endset %}
@@ -86,16 +80,14 @@
 {% set body %}
   <div class="u-align-right box-wrap">
     {{ content.field_authors }}
-    {% if related %}
-      {% include '@components/box/box--related-info/box--related-info.twig' with {
-        'modifier_classes': '',
-        'title': {
-          'tag': 'div',
-          'text': 'Related Information',
-          },
-        'content': related,
-      } only %}
-    {% endif %}
+    {% include '@components/box/box--related-info/box--related-info.twig' with {
+      'modifier_classes': '',
+      'title': {
+        'tag': 'div',
+        'text': 'Related Information',
+        },
+      'content': related,
+    } only %}
   </div>
   <h2>{{ author_names }}</h2>
   <h3>{{ content.field_release|field_value }} <br />{{ content.field_text_location|field_value }}</h3>


### PR DESCRIPTION
This update includes:

- Removal of hub links at the top of the page
- Added the title "Speeches and Remarks" in the web-area
- Added "Read more EPA Speeches and Remarks" link to related information which links to the parent web area. 
- Updated pattern lab to reflect latest updates. 

Notes: This feature branch is based from FEATURE-speeches-and-remarks. 

View:
https://integration.epa.byf1.dev/node/280290

JIRA:
https://forumone.atlassian.net/browse/EPAD8-2041