### PR TITLE
Epad8 2048 utility classes

### DIFF
--- a/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
+++ b/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
@@ -8,6 +8,7 @@ global:
     theme:
       css/core.css: {}
       css-lib/colorbox.min.css: {}
+      css/utilities.css: { weight: 50 }
   js:
     js/dist/scripts.min.js: {}
     js/dist/sitewide-alert.min.js: {}
@@ -108,7 +109,7 @@ block:
   version: VERSION
   css:
     theme:
-      css/block.css: { weight: -1 }
+      css/block.css: {}
 boxes:
   version: VERSION
   css:

--- a/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
+++ b/services/drupal/web/themes/epa_theme/epa_theme.libraries.yml
@@ -108,7 +108,7 @@ block:
   version: VERSION
   css:
     theme:
-      css/block.css: {}
+      css/block.css: { weight: -1 }
 boxes:
   version: VERSION
   css:

--- a/services/drupal/web/themes/epa_theme/source/core.scss
+++ b/services/drupal/web/themes/epa_theme/source/core.scss
@@ -102,9 +102,7 @@
 @forward '_patterns/05-components/video/video';
 @forward '_patterns/05-components/warning/warning';
 
-// USWDS and Gesso utility classes.
-// @forward 'uswds-utilities';
-// @forward '_patterns/utility-classes';
+// USWDS and Gesso utility classes - now in their own stylesheet utilities.css
 
 // Shame
 @forward '_patterns/shame';

--- a/services/drupal/web/themes/epa_theme/source/core.scss
+++ b/services/drupal/web/themes/epa_theme/source/core.scss
@@ -103,8 +103,8 @@
 @forward '_patterns/05-components/warning/warning';
 
 // USWDS and Gesso utility classes.
-@forward 'uswds-utilities';
-@forward '_patterns/utility-classes';
+// @forward 'uswds-utilities';
+// @forward '_patterns/utility-classes';
 
 // Shame
 @forward '_patterns/shame';

--- a/services/drupal/web/themes/epa_theme/source/utilities.scss
+++ b/services/drupal/web/themes/epa_theme/source/utilities.scss
@@ -1,0 +1,12 @@
+// @file
+// Utility styles
+// Configuration
+// @use '_patterns/00-config' as *;
+$wysiwyg: false !default;
+
+@forward '_patterns/00-config/config.settings';
+@forward '_patterns/00-config/uswds-theme.artifact' hide map-deep-get, strip-unit, typeset-heading, typeset-p, u-maxw;
+
+// USWDS and Gesso utility classes.
+@forward 'uswds-utilities';
+@forward '_patterns/utility-classes';

--- a/services/drupal/web/themes/epa_theme/source/utilities.scss
+++ b/services/drupal/web/themes/epa_theme/source/utilities.scss
@@ -1,10 +1,6 @@
 // @file
 // Utility styles
 // Configuration
-// @use '_patterns/00-config' as *;
-$wysiwyg: false !default;
-
-@forward '_patterns/00-config/config.settings';
 @forward '_patterns/00-config/uswds-theme.artifact' hide map-deep-get, strip-unit, typeset-heading, typeset-p, u-maxw;
 
 // USWDS and Gesso utility classes.


### PR DESCRIPTION
This PR creates a new stylesheet, utilities.css, that contains the uswds utility classes and our pattern utility classes. it is loaded theme wide with a weight of 50, which means it's always loaded as the last stylesheet. 

