### PR TITLE
EPAD9-2003: Convert On This Page to h2 element

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/03-page-with-wide-template.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/03-page-with-wide-template.twig
@@ -28,7 +28,7 @@
 {% set content %}
   <p class="disclaimer pdf">You may need a PDF reader to view some of the files on this page. See <a href="/home/pdf-files">EPA’s About PDF page</a> to learn more.</p>
   <p>Learn about EPA’s past involvement at the Aerovox Mill Site.</p>
-  <div>On this page:</div>
+  <h2 class="h4">On this page:</h2>
   <ul>
     <li><a href="#WhatsHappeningNow">What’s happening now?</a></li>
     <li>

--- a/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/regulation.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/07-pages/detail-pages/regulation.twig
@@ -25,7 +25,7 @@
     },
     'content': '<div class="field"><div class="field__label">Code of Federal Regulations Citation</div><ul class="field__content"><li><a href="#">40 CFR Part 63 Subpart FFFF</a></li></ul></div><div class="field"><div class="field__label">Docket Numbers</div><ul class="field__content"><li><a href="#">EPA-HQ-OAR-2003-0121</a></li><li><a href="#">EPA-HQ-OAR-2018-0746</a></li></ul></div>',
   } only %}
-  <p>On this page:</p>
+  <h2 class="h4">On this page:</h2>
   <ul>
     <li><a href="#rule-summary">Rule Summary</a></li>
     <li><a href="#rule-history">Rule History</a></li>

--- a/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/content/node--regulation--full.html.twig
@@ -67,7 +67,7 @@
     content.field_additional_resources|render or
     content.field_compliance|render
   %}
-    <p>On this page:</p>
+    <h2 class="h4">On this page:</h2>
     <ul>
       {% if content.field_rule_summary|render %}
         <li><a href="#rule-summary">{{ content.field_rule_summary|field_label }}</a></li>


### PR DESCRIPTION
This update converts the "On this page:" note to be in an 'H2' element with an 'H4' class for the Regulation content type in Drupal and Pattern Lab. 

View:
https://integration.epa.byf1.dev/education/regulation-page

JIRA:
https://forumone.atlassian.net/browse/EPAD8-2003