### PR TITLE
EPAD8-1882:FED work for  Media First and Inset options

### DIFF
--- a/services/drupal/web/themes/epa_theme/templates/paragraph/paragraph--card.html.twig
+++ b/services/drupal/web/themes/epa_theme/templates/paragraph/paragraph--card.html.twig
@@ -25,10 +25,21 @@
  */
 #}
 
+{% set paragraph_parent = paragraph.getParentEntity() %}
+
+{% if paragraph_parent.field_title_placement.0.value == 'header-first' %}
+  {% set title_first = 'usa-card--header-first' %}
+{% endif %}
+{% if paragraph_parent.field_image_style.0.value == 'inset' %}
+  {% set media_indent = 'usa-card__media--inset' %}
+{% endif %}
+
 {% include '@uswds/card/card.twig' with {
   'title': content.field_title|field_value,
   'content': content.field_body|field_value,
   'media': content.field_media_image|field_value,
   'button_url': content.field_link[0]['#url'],
   'button_text': paragraph.field_link.title,
+  'modifier_classes': title_first ? title_first : '',
+  'media_modifier_classes': media_indent ? media_indent : '',
 } %}


### PR DESCRIPTION
Cards in card groups work with the following options:

- Images will now display indent and extent in 50/50 and 33/33/33 views
- Header will now display first or below image on 33/33/33 view

Notes:
This branch is based from `EPAD8-1882-card-option-updates`

View:
https://integration.epa.byf1.dev/education/card-groups

JIRA:
https://forumone.atlassian.net/browse/EPAD8-1882