### PR TITLE
EPAD8-1935: change box blog to box perspectives, footer link styling

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/box--blog/_box--blog.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/box--blog/_box--blog.scss
@@ -32,13 +32,19 @@
   }
 
   > .box__footer > .box__footer-link {
-    color: gesso-grayscale(gray-7);
+    color: gesso-color(text, link);
 
-    &:visited,
+    &:visited {
+      color: gesso-color(text, link-visited);
+    }
+
     &:hover,
-    &:focus,
+    &:focus {
+      color: gesso-color(text, link-hover);
+    }
+
     &:active {
-      color: gesso-grayscale(gray-7);
+      color: gesso-color(text, link-active);
     }
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/box--blog/box--blog.md
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/box--blog/box--blog.md
@@ -1,6 +1,6 @@
 ---
 el: .box--blog
-title: Blog Box
+title: Perspectives Box
 state: complete
 ---
 


### PR DESCRIPTION
This PR changes the Pattern Lab name of `Blog Box` to `Perspectives Box`, but keeps all the classes the same. 

Updates the footer link to be blue like default links and confirmed the blue text / light green bg passes accessibility standards.