### PR TITLE
EPAD8-2174 revert back to top js from once to query selector

### DIFF
--- a/services/drupal/web/themes/epa_theme/js/src/modules/_back-to-top.es6.js
+++ b/services/drupal/web/themes/epa_theme/js/src/modules/_back-to-top.es6.js
@@ -6,7 +6,7 @@
  *   to the top.
  */
 export default function(threshold = 200, smoothScroll = true) {
-  const backToTop = once('back-to-top', '.back-to-top');
+  const backToTop = document.querySelector('.back-to-top');
   if (backToTop) {
     if (!isNaN(threshold)) {
       backToTop.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
This PR resets the change in back-to-top.js to use query selector instead of once. The once setting change was preventing the javascript from applying the correct classes to the back to top button. 