### PR TITLE
EPAD8-2156 update allowed links

### DIFF
--- a/services/drupal/web/themes/epa_theme/js/src/external-links.es6.js
+++ b/services/drupal/web/themes/epa_theme/js/src/external-links.es6.js
@@ -10,11 +10,18 @@ import Drupal from 'drupal';
         'clu-in.org',
         'energystar.gov',
         'relocatefeds.gov',
-        'urbanwaterpartners.gov',
         'urbanwaters.gov',
         'westcoastcollaborative.org',
         'usepa.sharepoint.com',
         'usepa.servicenowservices.com',
+        'epaoig.gov',
+        'fedcenter.gov',
+        'foiaonline.gov',
+        'frtr.gov',
+        'glnpo.gov',
+        'greengov.gov',
+        'sustainability.gov',
+        'glri.us',
       ];
 
       const epaSocialMediaLinks = [
@@ -28,6 +35,8 @@ import Drupal from 'drupal';
         'https://youtube.com/user/usepagov',
         'https://www.flickr.com/photos/usepagov',
         'https://flickr.com/photos/usepagov',
+        'https://www.linkedin.com/company/us-epa/',
+        'https://linkedin.com/company/us-epa/',
       ];
 
       function linkIsExternal(linkElement) {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/external-link.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/external-link.twig
@@ -82,8 +82,7 @@
   <div><a href="https://glnpo.gov">https://glnpo.gov</a></div>
   <div><a href="https://greengov.gov">https://greengov.gov</a></div>
   <div><a href="https://sustainability.gov">https://sustainability.gov</a></div>
-  <div><a href="https://glri.gov">https://glri.us</a></div>
-  <div><a href="https://glrilil.gov">https://glrilil.us</a></div>
+  <div><a href="https://glri.us">https://glri.us</a></div>
   <h2>External Allowed Social MediaLinks</h2>
   <div><a href="https://www.facebook.com/epa">https://www.facebook.com/epa</a></div>
   <div><a href="https://www.instagram.com/epagov">https://www.instagram.com/epagov</a></div>

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/external-link.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/external-link/external-link.twig
@@ -70,19 +70,27 @@
   <div><a href="http://sub.energystar.gov">http://sub.energystar.gov</a></div>
   <div><a href="http://relocatefeds.gov">http://relocatefeds.gov</a></div>
   <div><a href="http://sub.relocatefeds.gov">http://sub.relocatefeds.gov</a></div>
-  <div><a href="http://urbanwaterpartners.gov">http://urbanwaterpartners.gov</a></div>
-  <div><a href="http://sub.urbanwaterpartners.gov">http://sub.urbanwaterpartners.gov</a></div>
   <div><a href="http://urbanwaters.gov">http://urbanwaters.gov</a></div>
   <div><a href="http://sub.urbanwaters.gov">http://sub.urbanwaters.gov</a></div>
   <div><a href="http://westcoastcollaborative.org">http://westcoastcollaborative.org</a></div>
   <div><a href="http://sub.westcoastcollaborative.org">http://sub.westcoastcollaborative.org</a></div>
   <div><a href="https://usepa.servicenowservices.com/ecss">https://usepa.servicenowservices.com/ecss</a></div>
+  <div><a href="https://epaoig.gov">https://epaoig.gov</a></div>
+  <div><a href="https://fedcenter.gov">https://fedcenter.gov</a></div>
+  <div><a href="https://foiaonline.gov">https://foiaonline.gov</a></div>
+  <div><a href="https://frtr.gov">https://frtr.gov</a></div>
+  <div><a href="https://glnpo.gov">https://glnpo.gov</a></div>
+  <div><a href="https://greengov.gov">https://greengov.gov</a></div>
+  <div><a href="https://sustainability.gov">https://sustainability.gov</a></div>
+  <div><a href="https://glri.gov">https://glri.us</a></div>
+  <div><a href="https://glrilil.gov">https://glrilil.us</a></div>
   <h2>External Allowed Social MediaLinks</h2>
   <div><a href="https://www.facebook.com/epa">https://www.facebook.com/epa</a></div>
   <div><a href="https://www.instagram.com/epagov">https://www.instagram.com/epagov</a></div>
   <div><a href="https://www.twitter.com/epa">https://www.twitter.com/epa</a></div>
   <div><a href="https://www.youtube.com/user/usepagov">https://www.youtube.com/user/usepagov</a></div>
   <div><a href="https://www.flickr.com/photos/usepagov">https://www.flickr.com/photos/usepagov</a></div>
+  <div><a href="https://www.linkedin.com/company/us-epa/">https://www.linkedin.com/company/us-epa/</a></div>
 
   <h2>Protected Internal Links</h2>
   <div><a href="http://work.epa.gov">http://work.epa.gov</a></div>


### PR DESCRIPTION
This PR updates the allowed list with the newly requested URLs, adds linkedin to the social media allowed list, and removes Urban Water Partners from the allowed list. This PR also updates the list in Pattern Lab. 