### PR TITLE
EPAD8-2071: Upgrade NR APM agent

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -29,7 +29,7 @@ FROM forumone/drupal8:8.0 AS base
 # not configure the extension here. That must happen at runtime since the license keys
 # and application names are environment-dependent.
 RUN set -ex \
-  && NEW_RELIC_AGENT_VERSION=9.21.0.311 \
+  && NEW_RELIC_AGENT_VERSION=10.11.0.3 \
   && curl -L https://download.newrelic.com/php_agent/archive/$NEW_RELIC_AGENT_VERSION/newrelic-php5-$NEW_RELIC_AGENT_VERSION-linux-musl.tar.gz | tar -C /tmp -zx \
   && export NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 \
   && /tmp/newrelic-php5-$NEW_RELIC_AGENT_VERSION-linux-musl/newrelic-install install \
@@ -223,7 +223,7 @@ FROM forumone/drupal8-cli:8.0 AS drush
 
 # Download and install New Relic
 RUN set -ex \
-  && NEW_RELIC_AGENT_VERSION=9.21.0.311 \
+  && NEW_RELIC_AGENT_VERSION=10.11.0.3 \
   && curl -L https://download.newrelic.com/php_agent/archive/$NEW_RELIC_AGENT_VERSION/newrelic-php5-$NEW_RELIC_AGENT_VERSION-linux-musl.tar.gz | tar -C /tmp -zx \
   && export NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=1 \
   && /tmp/newrelic-php5-$NEW_RELIC_AGENT_VERSION-linux-musl/newrelic-install install \


### PR DESCRIPTION
This PR upgrades the New Relic APM agent. It appears our in-browser agent snippet comes from the APM, so this should have the happy effect of upgrading both at the same time.