### PR TITLE
[EPAD8-1134] Disabling front page metadata configuration so that the …

### DIFF
--- a/services/drupal/config/sync/metatag.metatag_defaults.front.yml
+++ b/services/drupal/config/sync/metatag.metatag_defaults.front.yml
@@ -1,6 +1,6 @@
 uuid: 50724a18-52a9-492a-ae7f-96f94d41efc6
 langcode: en
-status: true
+status: false
 dependencies: {  }
 _core:
   default_config_hash: 1noCXlegCr5HFehQRF1ViXy1jhU1jZ_sNN99a8Sj5jo


### PR DESCRIPTION
…default content configuration can take over and place the correct metadata.