### PR TITLE
EPAD8-2241: Ignore version tokens in responses

### DIFF
--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -8,6 +8,9 @@ server {
   server_name _;
   listen 443 default_server;
 
+  # Do not report specific nginx version
+  server_tokens off;
+
   server_name_in_redirect off;
   if ($new_uri_301 ~ ^/) {
     # For redirect paths that are relative to the current domain (such as the
@@ -98,6 +101,9 @@ server {
 
     # Replace REMOTE_ADDR with the forwarded IP from the load balancer
     fastcgi_param REMOTE_ADDR $realip_remote_addr;
+
+    # Ignore PHP's X-Powered-By header
+    fastcgi_hide_header X-Powered-By;
 
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;


### PR DESCRIPTION
This PR tells nginx to not output any version information in responses, both ignoring its own output (the `server_tokens` directive) and PHP's (the `fastcgi_ignore_header` directive).