### PR TITLE
EPAD8-2272: Implement schedule scaling

### DIFF
--- a/terraform/webcms/drupal_schedule.tf
+++ b/terraform/webcms/drupal_schedule.tf
@@ -8,8 +8,8 @@ resource "aws_appautoscaling_scheduled_action" "drupal_scale_out" {
   scalable_dimension = aws_appautoscaling_target.drupal.scalable_dimension
   service_namespace  = aws_appautoscaling_target.drupal.service_namespace
 
-  # Schedule expression: at 7:30 AM, Monday-Friday, US Eastern time zone
-  schedule = "cron(30 7 * * MON-FRI *)"
+  # Schedule expression: at 6:00 AM, Monday-Friday, US Eastern time zone
+  schedule = "cron(0 6 * * MON-FRI *)"
   timezone = "America/New_York"
 
   scalable_target_action {
@@ -29,8 +29,8 @@ resource "aws_appautoscaling_scheduled_action" "drupal_scale_in" {
   scalable_dimension = aws_appautoscaling_target.drupal.scalable_dimension
   service_namespace  = aws_appautoscaling_target.drupal.service_namespace
 
-  # Schedule expression: at 7:30 PM, Monday-Friday, US Eastern time zone
-  schedule = "cron(30 19 * * MON-FRI *)"
+  # Schedule expression: at 5:00 PM, Monday-Friday, US Eastern time zone
+  schedule = "cron(0 17 * * MON-FRI *)"
   timezone = "America/New_York"
 
   scalable_target_action {

--- a/terraform/webcms/drupal_schedule.tf
+++ b/terraform/webcms/drupal_schedule.tf
@@ -1,0 +1,35 @@
+resource "aws_appautoscaling_scheduled_action" "drupal_scale_in" {
+  count = var.drupal_schedule_min_capacity != null ? 1 : 0
+
+  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal-schedule-in"
+
+  resource_id        = aws_appautoscaling_target.drupal.id
+  scalable_dimension = aws_appautoscaling_target.drupal.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.drupal.service_namespace
+
+  # Schedule expression: at 7:30 AM, Monday-Friday, US Eastern time zone
+  schedule = "cron(30 7 * * MON-FRI *)"
+  timezone = "America/New_York"
+
+  scalable_target_action {
+    min_capacity = var.drupal_schedule_min_capacity
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "drupal_scale_in" {
+  count = var.drupal_schedule_min_capacity != null ? 1 : 0
+
+  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal-schedule-out"
+
+  resource_id        = aws_appautoscaling_target.drupal.id
+  scalable_dimension = aws_appautoscaling_target.drupal.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.drupal.service_namespace
+
+  # Schedule expression: at 7:30 PM, Monday-Friday, US Eastern time zone
+  schedule = "cron(30 19 * * MON-FRI *)"
+  timezone = "America/New_York"
+
+  scalable_target_action {
+    min_capacity = var.drupal_min_capacity
+  }
+}

--- a/terraform/webcms/drupal_schedule.tf
+++ b/terraform/webcms/drupal_schedule.tf
@@ -1,7 +1,8 @@
-resource "aws_appautoscaling_scheduled_action" "drupal_scale_in" {
+# Schedule scaling: Increase the task minimum before US Eastern working hours.
+resource "aws_appautoscaling_scheduled_action" "drupal_scale_out" {
   count = var.drupal_schedule_min_capacity != null ? 1 : 0
 
-  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal-schedule-in"
+  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal-schedule-out"
 
   resource_id        = aws_appautoscaling_target.drupal.id
   scalable_dimension = aws_appautoscaling_target.drupal.scalable_dimension
@@ -16,10 +17,13 @@ resource "aws_appautoscaling_scheduled_action" "drupal_scale_in" {
   }
 }
 
+# Schedule scaling: Decrease the task minimum after US Eastern working hours.
+# Since this only lowers the minimum, it should not negatively impact authors in
+# more western time zones.
 resource "aws_appautoscaling_scheduled_action" "drupal_scale_in" {
   count = var.drupal_schedule_min_capacity != null ? 1 : 0
 
-  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal-schedule-out"
+  name = "webcms-${var.environment}-${var.site}-${var.lang}-drupal-schedule-int"
 
   resource_id        = aws_appautoscaling_target.drupal.id
   scalable_dimension = aws_appautoscaling_target.drupal.scalable_dimension

--- a/terraform/webcms/variables.tf
+++ b/terraform/webcms/variables.tf
@@ -71,6 +71,13 @@ variable "drupal_min_capacity" {
   default     = 1
 }
 
+variable "drupal_schedule_min_capacity" {
+  description = "When using scheduled scaling, the elevated minimum number of Drupal tasks to run during working hours"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
 variable "drupal_max_capacity" {
   description = "Maximum number of Drupal tasks to run in the cluster"
   type        = number

--- a/terraform/webcms/variables.tf
+++ b/terraform/webcms/variables.tf
@@ -74,7 +74,6 @@ variable "drupal_min_capacity" {
 variable "drupal_schedule_min_capacity" {
   description = "When using scheduled scaling, the elevated minimum number of Drupal tasks to run during working hours"
   type        = number
-  nullable    = true
   default     = null
 }
 


### PR DESCRIPTION
This PR implements a scheduled scaling policy in order to elevate the minimum task count before US Eastern working hours, since the majority of the site's content editors are in this time zone. In the evening, the minimum task count is lowered in order to allow ECS to gradually scale in overnight.