### PR TITLE
EPAD8-2273: Request count scaling

### DIFF
--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -298,13 +298,13 @@ resource "aws_appautoscaling_policy" "drupal_autoscaling_requests" {
 
   target_tracking_scaling_policy_configuration {
     # Ask ECS to average around 100 requests/target
-    target_value = 100
+    target_value = 150
 
     scale_in_cooldown  = 5 * 60
     scale_out_cooldown = 60
 
     predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+      predefined_metric_type = "ALBRequestCountPerTarget"
     }
   }
 }


### PR DESCRIPTION
This PR implements a second scaling policy, where the request count average in the ALB is also respected as a scaling parameter. Right now, ECS is asked to maintain an average of 150 requests per task, but this value is readily changed.