### PR TITLE
Epad8 1332 alert sizing

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/alert/_alert.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/alert/_alert.scss
@@ -3,4 +3,8 @@
 .usa-alert {
   margin-bottom: rem(gesso-spacing(2));
   overflow: auto;
+
+  .usa-alert__body {
+    max-width: 100%;
+  }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/site-alert/_site-alert.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/site-alert/_site-alert.scss
@@ -4,6 +4,10 @@
   .usa-alert {
     margin-bottom: 0;
     overflow: visible;
+
+    .usa-alert__body {
+      max-width: 100%;
+    }
   }
 
   .usa-alert__text {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/site-alert/site-alert--private/_site-alert--private.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/site-alert/site-alert--private/_site-alert--private.scss
@@ -37,6 +37,7 @@
       );
 
       align-items: flex-start;
+      max-width: rem($max-width);
       padding-left: rem(68px);
     }
   }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/site-alert/site-alert--private/_site-alert--private.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/site-alert/site-alert--private/_site-alert--private.scss
@@ -37,7 +37,7 @@
       );
 
       align-items: flex-start;
-      max-width: rem($max-width);
+      max-width: uswds(banner-max-width);
       padding-left: rem(68px);
     }
   }


### PR DESCRIPTION
This PR fixes a bug where the site alerts weren't filling up the banner space fully. It also adds a narrow restriction to the private files alert so that it matches the figma file.  