### PR TITLE
EPAD8-2040 accordion facets allow for multiple, update pattern lab

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/accordion/accordion--multiselectable/accordion--multiselectable.md
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/accordion/accordion--multiselectable/accordion--multiselectable.md
@@ -1,5 +1,5 @@
 ---
-el: .usa-accordion[aria-multiselectable="true"]
+el: .usa-accordion[data-allow-multiple]
 title: Multi Selectable Accordion
 state: complete
 ---

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/accordion/accordion.twig
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/accordion/accordion.twig
@@ -5,7 +5,7 @@
 
 {% set accordion_id = 'accordion'|unique_id %}
 
-<div class="{{ classes }}"{% if is_multi_selectable %} aria-multiselectable="true"{% endif %}>
+<div class="{{ classes }}"{% if is_multi_selectable %} data-allow-multiple{% endif %}>
   {% if pattern_lab %}
     {% for item in accordion %}
       {% include '@uswds/accordion/_accordion-content.twig' with {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/06-templates/listing-pages/listing-page.yml
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/06-templates/listing-pages/listing-page.yml
@@ -18,7 +18,7 @@ filters: |-
   <h2 class="h5 margin-bottom-5">Displaying 1-15 of 1629 results</h2>
 sidebar: |-
   <h2 class="h3">Filter By:</h2>
-  <div class="usa-accordion usa-accordion--bordered margin-bottom-4" aria-multiselectable="true">
+  <div class="usa-accordion usa-accordion--bordered margin-bottom-4" data-allow-multiple>
     <h3 class="usa-accordion__heading">
       <button class="usa-accordion__button" aria-expanded="false" aria-controls="facets-a1">
         Category


### PR DESCRIPTION
This PR updates the multiple accordion syntax to use the updated USWDS so that facets on search pages can have multiple expanded at once. It also updates pattern lab to use the correct syntax and reflects the live experience. 