### PR TITLE
EPAD8-2114 dark background styles for summary box

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
@@ -33,6 +33,6 @@
   clear: none;
 
   .usa-dark-background & {
-    color: gesso-brand(blue, base)
+    color: gesso-color(text, primary);
   }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
@@ -31,4 +31,8 @@
 
 .usa-summary-box__heading {
   clear: none;
+
+  .usa-dark-background & {
+    color: gesso-brand(blue, base)
+  }
 }

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
@@ -1,3 +1,6 @@
+@use '../../00-config' as *;
+@use '../../02-base/03-extendables' as *;
+
 .usa-summary-box {
   overflow: auto;
 }
@@ -10,6 +13,19 @@
 .usa-summary-box__text {
   > :last-child {
     margin-bottom: 0;
+  }
+
+  .usa-dark-background & {
+    color: gesso-color(text, primary);
+
+    a:not(.usa-button, .button) {
+      @extend %light-bg-link;
+    }
+
+    p,
+    span {
+      color: gesso-color(text, primary);
+    }
   }
 }
 


### PR DESCRIPTION
this PR styles the default summary box text and links when they're on dark backgrounds so that they meet accessibility standards. 