### PR TITLE
Epad8 2334 private 508 bug

### DIFF
--- a/services/drupal/web/themes/epa_theme/js/src/private-sitewide-alert.es6.js
+++ b/services/drupal/web/themes/epa_theme/js/src/private-sitewide-alert.es6.js
@@ -8,7 +8,7 @@ import Drupal from 'drupal';
       const privateMediaCount = privateMedia.length;
 
       if (privateMediaCount > 0) {
-        const nodeHTML = document.querySelector('body');
+        const nodeHTML = context.querySelector('body');
         const dataAlert = document.title.replace(/\s+/g, '-').toLowerCase();
 
         const privateMediaAlert = `<div class="usa-site-alert usa-site-alert--has-heading usa-site-alert--private js-sitewide-alert" data-alert="${dataAlert}">

--- a/services/drupal/web/themes/epa_theme/js/src/private-sitewide-alert.es6.js
+++ b/services/drupal/web/themes/epa_theme/js/src/private-sitewide-alert.es6.js
@@ -4,29 +4,33 @@ import Drupal from 'drupal';
 (function(Drupal) {
   Drupal.behaviors.sitewideAlertPrivate = {
     attach(context) {
-      const privateMedia = document.getElementsByClassName('js-media-private');
-      const privateMediaCount = privateMedia.length;
+      once('sitewide-alert-private', 'body').forEach(() => {
+        const privateMedia = document.getElementsByClassName(
+          'js-media-private'
+        );
+        const privateMediaCount = privateMedia.length;
 
-      if (privateMediaCount > 0) {
-        const nodeHTML = context.querySelector('body');
-        const dataAlert = document.title.replace(/\s+/g, '-').toLowerCase();
+        if (privateMediaCount > 0) {
+          const nodeHTML = context.querySelector('body');
+          const dataAlert = document.title.replace(/\s+/g, '-').toLowerCase();
 
-        const privateMediaAlert = `<div class="usa-site-alert usa-site-alert--has-heading usa-site-alert--private js-sitewide-alert" data-alert="${dataAlert}">
-          <div class="usa-alert">
-            <div class="usa-alert__body">
-              <div class="u-visually-hidden">Notice</div>
-              <div class="usa-alert__content">
-                <h3 class="usa-alert__heading">This page contains <span id="js-private-media-count">${privateMediaCount}</span> media files that are marked private.</h3>
-                <div class="usa-alert__text">
-                  <p>These files have been marked private and will not be available to anonymous readers. To make these files public, please read this page, <a href="https://www.epa.gov/webcmstraining/sensitive-private-vs-public-files">Sensitive (Private) vs Public Files</a>.</p>
+          const privateMediaAlert = `<div class="usa-site-alert usa-site-alert--has-heading usa-site-alert--private js-sitewide-alert" data-alert="${dataAlert}">
+            <div class="usa-alert">
+              <div class="usa-alert__body">
+                <div class="u-visually-hidden">Notice</div>
+                <div class="usa-alert__content">
+                  <h3 class="usa-alert__heading">This page contains <span id="js-private-media-count">${privateMediaCount}</span> media files that are marked private.</h3>
+                  <div class="usa-alert__text">
+                    <p>These files have been marked private and will not be available to anonymous readers. To make these files public, please read this page, <a href="https://www.epa.gov/webcmstraining/sensitive-private-vs-public-files">Sensitive (Private) vs Public Files</a>.</p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>`;
+          </div>`;
 
-        nodeHTML.innerHTML = nodeHTML.innerHTML + privateMediaAlert;
-      }
+          nodeHTML.innerHTML = nodeHTML.innerHTML + privateMediaAlert;
+        }
+      });
     },
   };
 })(Drupal);


### PR DESCRIPTION
This PR fixes the issue when there is a private file on a page the 508 compliance box won't show up.

The private file alert banner was being added to the body using the document, rather than the context, which was causing the dynamically loading compliance box to stay hidden. Once updated, there was a console error, so I refactored the code slightly to use once so that it would only fire once. 