### PR TITLE
EPAD8-2288 h2 box title not bordered is smaller

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/_box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/_box.scss
@@ -39,6 +39,12 @@ div.box__title {
   @extend %h3;
 }
 
+h2.box__title {
+  @include breakpoint(gesso-breakpoint(tablet)) {
+    font-size: rem(28px);
+  }
+}
+
 .box__image-link {
   &#{$external-urls} {
     @extend .external-link--image;


### PR DESCRIPTION
makes h2's that are titles on boxes that are not bordered 28px