### PR TITLE
EPAD8-2184 definitions cut off

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
@@ -2,7 +2,13 @@
 @use '../../02-base/03-extendables' as *;
 
 .usa-summary-box {
-  overflow: auto;
+  overflow: visible;
+
+  &:before,
+  &:after {
+    clear: both;
+    content: '';
+  }
 }
 
 .usa-summary-box__body {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/03-uswds/summary-box/_summary-box.scss
@@ -8,11 +8,12 @@
   &:after {
     clear: both;
     content: '';
+    display: table;
   }
 }
 
 .usa-summary-box__body {
-  overflow: hidden;
+  overflow: visible;
 }
 
 .usa-summary-box__body,

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/_box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/_box.scss
@@ -8,7 +8,13 @@
 .box {
   margin-bottom: rem(units(4));
   max-width: 100%;
-  overflow: auto;
+  overflow: visible;
+
+  &:before,
+  &:after {
+    clear: both;
+    content: '';
+  }
 
   @include breakpoint(gesso-breakpoint(tablet)) {
     &.u-align-left,

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/_box.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/box/_box.scss
@@ -14,6 +14,7 @@
   &:after {
     clear: both;
     content: '';
+    display: table;
   }
 
   @include breakpoint(gesso-breakpoint(tablet)) {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
@@ -46,6 +46,10 @@
   a:not(.usa-button, .button) {
     @extend %dark-bg-link;
   }
+
+  .l-sidebar__sidebar & {
+    min-width: rem(150px);
+  }
 }
 
 .definition__term {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
@@ -38,17 +38,20 @@
   font-size: font-size(body, xs);
   margin-top: rem(-3px);
   max-width: rem(960px);
-  min-width: rem(320px);
   padding: gesso-spacing(2);
   position: absolute;
   z-index: 1;
 
-  a:not(.usa-button, .button) {
-    @extend %dark-bg-link;
+  @include breakpoint(gesso-breakpoint(tablet)) {
+    min-width: rem(320px);
+
+    .l-sidebar__sidebar & {
+      min-width: rem(150px);
+    }
   }
 
-  .l-sidebar__sidebar & {
-    min-width: rem(150px);
+  a:not(.usa-button, .button) {
+    @extend %dark-bg-link;
   }
 }
 

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
@@ -40,6 +40,7 @@
   max-width: rem(960px);
   padding: gesso-spacing(2);
   position: absolute;
+  word-break: break-word;
   z-index: 1;
 
   @include breakpoint(gesso-breakpoint(tablet)) {

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/definition/_definition.scss
@@ -38,6 +38,7 @@
   font-size: font-size(body, xs);
   margin-top: rem(-3px);
   max-width: rem(960px);
+  min-width: rem(320px);
   padding: gesso-spacing(2);
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
this PR addresses oddities with the definitions popup in different parent containers.
it:

- removes the overflow auto on boxes so that definitions don't scroll within the box. Adds clearfix items to account for potential float issues
- adds a min width to the definition so that when the parent is really small, like in a narrow table, the definition tooltip is has enough reading room.