### PR TITLE
EPAD8-2384: Remove CloudWatch agent

### DIFF
--- a/terraform/infrastructure/README.md
+++ b/terraform/infrastructure/README.md
@@ -20,7 +20,6 @@
 - [Post-Run Steps](#post-run-steps)
   - [Initialize the Database](#initialize-the-database)
   - [Populate Secrets](#populate-secrets)
-  - [Mirror Images](#mirror-images)
 - [Known Issues](#known-issues)
 
 ## About
@@ -146,20 +145,6 @@ There are a number of sensitive values that must be populated by an administrato
 1. The Drupal hash salt must be generated and saved in `/webcms/${var.environment}/${site}/${lang}/drupal-hash-salt`. This value **must** differ between site/language combinations in order to prevent one-time tokens such as password resets from being reused. Use a secure random number generator such as the `openssl rand` utility to generate a large number of bytes (at least 32).
 2. For email, the SMTP password must be saved in the secret `/webcms/${var.environment}/${site}/${lang}/mail-password`.
 3. An x509 certificate and private key will need to be generated for each Drupal site and language. The private key needs to be set in `/webcms/${var.environment}/${site}/${lang}/saml-sp-key`.
-
-### Mirror Images
-
-The [ECR mirrors](#ecr-mirrors) need to be populated in order to bring the [Amazon CloudWatch Agent](https://hub.docker.com/r/amazon/cloudwatch-agent) into the AWS perimeter.
-
-These steps should suffice to mirror the image from the Docker Hub to ECR. Remember to [authenticate with ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token) prior to running the `docker push` commands.
-
-```sh
-docker pull amazon/cloudwatch-agent:latest
-docker tag amazon/cloudwatch-agent:latest <account>.dkr.ecr.<region>.amazonaws.com/webcms-<environment>-aws-cloudwatch:latest
-docker push <account>.dkr.ecr.<region>.amazonaws.com/webcms-<environment>-aws-cloudwatch:latest
-```
-
-In order to capture updates to these images, these pull/push steps should be run on an automated schedule.
 
 ## Known Issues
 

--- a/terraform/infrastructure/ecr.tf
+++ b/terraform/infrastructure/ecr.tf
@@ -40,20 +40,6 @@ resource "aws_ecr_repository" "metrics" {
   tags = var.tags
 }
 
-# The repositories here are mirrors of images on the Docker Hub. We bring them inside the
-# AWS perimeter because we are required to statically analyze *all* images prior to
-# deployment - not just custom ones.
-#
-# Mirrors are treated as being environment-wide resources, and thus do not have a for_each
-# associated with them.
-
-# This mirrors docker.io/amazon/cloudwatch-agent:latest
-resource "aws_ecr_repository" "cloudwatch_agent_mirror" {
-  name = "webcms-${var.environment}-aws-cloudwatch"
-
-  tags = var.tags
-}
-
 # Finally, we create a cache repository for Kaniko-based builds. This repository has some
 # lifecycle policies that aggressively expire images in order to avoid an arbitrarily large
 # cache from building up (see below).

--- a/terraform/infrastructure/logging.tf
+++ b/terraform/infrastructure/logging.tf
@@ -34,15 +34,6 @@ resource "aws_cloudwatch_log_group" "drupal" {
   tags = var.tags
 }
 
-# Log group for the CloudWatch agent
-resource "aws_cloudwatch_log_group" "agent" {
-  for_each = local.sites
-
-  name = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/cloudwatch-agent"
-
-  tags = var.tags
-}
-
 # Log group for the FPM metrics helper
 resource "aws_cloudwatch_log_group" "fpm_metrics" {
   for_each = local.sites

--- a/terraform/infrastructure/parameters.tf
+++ b/terraform/infrastructure/parameters.tf
@@ -161,16 +161,6 @@ resource "aws_ssm_parameter" "ecr_metrics" {
   tags = var.tags
 }
 
-resource "aws_ssm_parameter" "ecr_cloudwatch" {
-  for_each = local.sites
-
-  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/ecr/cloudwatch"
-  type  = "String"
-  value = aws_ecr_repository.cloudwatch_agent_mirror.repository_url
-
-  tags = var.tags
-}
-
 #endregion
 
 #region Log groups
@@ -201,16 +191,6 @@ resource "aws_ssm_parameter" "drush_log_group" {
   name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/log-groups/drush"
   type  = "String"
   value = aws_cloudwatch_log_group.drush[each.key].name
-
-  tags = var.tags
-}
-
-resource "aws_ssm_parameter" "agent_log_group" {
-  for_each = local.sites
-
-  name  = "/webcms/${var.environment}/${each.value.site}/${each.value.lang}/log-groups/cloudwatch-agent"
-  type  = "String"
-  value = aws_cloudwatch_log_group.agent[each.key].name
 
   tags = var.tags
 }

--- a/terraform/webcms/README.md
+++ b/terraform/webcms/README.md
@@ -173,7 +173,6 @@ As with the infrastructure and database modules, this module assumes that certai
 - Log group identifiers are also read from Parameter Store:
   - `/webcms/${var.environment}/${var.site}/${var.lang}log-groups/php-fpm`: The name of the log group for Drupal's PHP-FPM container.
   - `/webcms/${var.environment}/${var.site}/${var.lang}log-groups/nginx`: The name of the log group for Drupal's nginx container.
-  - `/webcms/${var.environment}/${var.site}/${var.lang}log-groups/cloudwatch-agent`: The name of the log group for Drupal's Cloudwatch agent container.
   - `/webcms/${var.environment}/${var.site}/${var.lang}log-groups/fpm-metrics`: The name of the log group for for Drupal's FPM metrics container.
   - `/webcms/${var.environment}/${var.site}/${var.lang}log-groups/drush`: The name of the log group for Drush runs.
   - `/webcms/${var.environment}/${var.site}/${var.lang}log-groups/drupal`: The name of the log group for Drupal application logs.
@@ -188,7 +187,7 @@ As with the infrastructure and database modules, this module assumes that certai
 
 ### Drupal
 
-This module creates an ECS task definition and service for running the WebCMS. This task includes a pair of containers, nginx and PHP-FPM, that handle incoming web traffic. In addition, a Cloudwatch agent container runs in order to ingest metric data pushed from Drupal (see the epa_metrics module). Finally, a fourth container runs a basic Alpine image that gathers PHP-FPM metrics every 60 seconds and publishes them to CloudWatch.
+This module creates an ECS task definition and service for running the WebCMS. This task includes a pair of containers, nginx and PHP-FPM, that handle incoming web traffic. In addition, a third container runs a basic Alpine image that gathers PHP-FPM metrics every 60 seconds and publishes them to CloudWatch.
 
 An autoscaling policy is attached to the Drupal service that tracks 60% CPU utilization. Scale-out is more aggressive than scale-in by a factor of five. We enforce slow scale in due to the relatively slow warm-up time of the Drupal containers; a long cooldown smooths out spiky traffic patterns and keeps containers from exhibiting thrashing-like behavior as opcache warms up.
 

--- a/terraform/webcms/drupal.tf
+++ b/terraform/webcms/drupal.tf
@@ -121,41 +121,6 @@ resource "aws_ecs_task_definition" "drupal_task" {
       }
     },
 
-    # In ECS, Amazon's CloudWatch agent can be run to collect application metrics. See
-    # the epa_metrics module for what we export to the agent.
-    {
-      name  = "cloudwatch"
-      image = "${data.aws_ssm_parameter.ecr_cloudwatch.value}:latest"
-
-      # The agent reads its JSON-formatted configuration from the environment in containers
-      environment = [
-        {
-          name = "CW_CONFIG_CONTENT"
-          # cf. https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html
-          value = jsonencode({
-            metrics = {
-              namespace = "WebCMS",
-              metrics_collected = {
-                statsd = {
-                  service_address = ":8125"
-                },
-              },
-            },
-          }),
-        },
-      ],
-
-      logConfiguration = {
-        logDriver = "awslogs"
-
-        options = {
-          awslogs-group         = data.aws_ssm_parameter.agent_log_group.value
-          awslogs-region        = var.aws_region
-          awslogs-stream-prefix = "cloudwatch"
-        }
-      }
-    },
-
     # Report FPM metrics to CloudWatch using the custom metrics container. See the
     # services/metrics directory for more.
     {

--- a/terraform/webcms/shared.tf
+++ b/terraform/webcms/shared.tf
@@ -94,10 +94,6 @@ data "aws_ssm_parameter" "ecr_metrics" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/ecr/metrics"
 }
 
-data "aws_ssm_parameter" "ecr_cloudwatch" {
-  name = "/webcms/${var.environment}/${var.site}/${var.lang}/ecr/cloudwatch"
-}
-
 #endregion
 
 #region Log groups
@@ -112,10 +108,6 @@ data "aws_ssm_parameter" "nginx_log_group" {
 
 data "aws_ssm_parameter" "drush_log_group" {
   name = "/webcms/${var.environment}/${var.site}/${var.lang}/log-groups/drush"
-}
-
-data "aws_ssm_parameter" "agent_log_group" {
-  name = "/webcms/${var.environment}/${var.site}/${var.lang}/log-groups/cloudwatch-agent"
 }
 
 data "aws_ssm_parameter" "fpm_metrics_log_group" {


### PR DESCRIPTION
This PR removes the CloudWatch agent used to gather metrics published via the now-inactive `epa_metrics` module.