### PR TITLE
EPAD8-2370: Switch metrics container to Debian to bring in latest AWS CLI

### DIFF
--- a/.buildkite/feature.yml
+++ b/.buildkite/feature.yml
@@ -117,24 +117,11 @@ steps:
         concurrency_group: $BUILDKITE_PIPELINE_SLUG/build-$BUILDKITE_BRANCH
         concurrency: 4
 
+        commands: docker build services/metrics
+
         plugins:
           - cultureamp/aws-assume-role#v0.1.0:
               role: arn:aws:iam::316981092358:role/BuildkiteRoleForImageBuilds
-
-          - docker#v3.12.0:
-              image: gcr.io/kaniko-project/executor:debug
-              workdir: /workspace
-
-              propagate-aws-auth-tokens: true
-
-              entrypoint: /bin/sh
-              command:
-                - -ec
-                - |
-                    echo '{"credsStore":"ecr-login"}' >/kaniko/.docker/config.json
-                    /kaniko/executor \
-                      --context=/workspace/services/metrics \
-                      --no-push
 
   # Perform a Terraform formatting check. See the terraform-fmt.sh script for more details
   # on what is executed in this step.

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -80,24 +80,13 @@ steps:
         concurrency_group: $BUILDKITE_PIPELINE_SLUG/build-$BUILDKITE_BRANCH
         concurrency: 4
 
+        commands:
+          - docker build services/metrics --tag "${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-fpm-metrics:${WEBCMS_IMAGE_TAG}"
+          - docker push "${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-fpm-metrics:${WEBCMS_IMAGE_TAG}"
+
         plugins:
           - cultureamp/aws-assume-role#v0.1.0:
               role: arn:aws:iam::316981092358:role/BuildkiteRoleForImageBuilds
-
-          - docker#v3.12.0:
-              image: gcr.io/kaniko-project/executor:debug
-              workdir: /workspace
-
-              propagate-aws-auth-tokens: true
-
-              entrypoint: /bin/sh
-              command:
-                - -ec
-                - |
-                    echo '{"credsStore":"ecr-login"}' >/kaniko/.docker/config.json
-                    /kaniko/executor \
-                      --context=/workspace/services/metrics \
-                      --destination="${WEBCMS_REPO_URL}/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-fpm-metrics:${WEBCMS_IMAGE_TAG}"
 
   - wait: ~
 

--- a/services/metrics/Dockerfile
+++ b/services/metrics/Dockerfile
@@ -1,6 +1,25 @@
-FROM alpine:latest
+FROM debian:stable-slim
 
-RUN apk add --no-cache aws-cli curl jq
+RUN set -ex \
+  # 1. Install packages needed for this container
+  && apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    curl \
+    jq \
+    unzip \
+  # 2. Download and install the latest AWS CLI
+  && cd /tmp \
+  && curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+  && unzip awscliv2.zip \
+  && ./aws/install \
+  # 3. Clean up the CLI installer files
+  && rm -rf ./aws awscliv2.zip \
+  # 4. Remove unneeded packages by marking them as automatic and letting the
+  #    'autoremove' command do its thing
+  && apt-mark auto unzip \
+  && apt-get autoremove --purge --yes \
+  && rm -rf /var/apt/lists/*
 
 COPY transform.jq /etc/transform.jq
 COPY entrypoint.sh /bin/entrypoint.sh


### PR DESCRIPTION
This PR switches out the Alpine-based metrics container with Debian in order to download the latest AWS CLI.

Note that the commits mentioning Kaniko issues are due to issues within our Buildkite environment, not others, so there are no issues to notify upstream about.