### PR TITLE
Support long-running Drush tasks

### DIFF
--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -115,9 +115,6 @@ steps:
     concurrency: 1
 
     plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks
-
       - docker#v3.8.0:
           image: node:14-alpine
           entrypoint: /bin/sh
@@ -149,9 +146,6 @@ steps:
     concurrency: 1
 
     plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks
-
       - docker#v3.8.0:
           image: node:14-alpine
           entrypoint: /bin/sh

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -124,9 +124,14 @@ steps:
           command:
             - -ec
             - |
+              mkdir -p ~/.aws
+              echo '[drush]' >> ~/.aws/credentials
+              echo 'role_arn = arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks' >> ~/.aws/credentials
+              echo 'credential_source = Ec2InstanceMetadata' >> ~/.aws/credentials
+
               cd ci
               npm ci
-              node drush.js
+              AWS_PROFILE=drush node drush.js
 
           propagate-aws-auth-tokens: true
           environment:

--- a/.buildkite/webcms.yml
+++ b/.buildkite/webcms.yml
@@ -158,9 +158,14 @@ steps:
           command:
             - -ec
             - |
+              mkdir -p ~/.aws
+              echo '[drush]' >> ~/.aws/credentials
+              echo 'role_arn = arn:aws:iam::316981092358:role/BuildkiteRoleForECSTasks' >> ~/.aws/credentials
+              echo 'credential_source = Ec2InstanceMetadata' >> ~/.aws/credentials
+
               cd ci
               npm ci
-              node drush.js
+              AWS_PROFILE=drush node drush.js
 
           propagate-aws-auth-tokens: true
           environment:


### PR DESCRIPTION
This PR allows long-running ECS tasks by changing how the Drush CI script loads authentication credentials. It's a relatively small change that is easy to test: if Drush is still able to be dispatched, then this change will work for tasks of any length.