### PR TITLE
EPAD8-2216: Add ECR lifecycle policies

### DIFF
--- a/terraform/infrastructure/ecr.tf
+++ b/terraform/infrastructure/ecr.tf
@@ -1,5 +1,41 @@
 # ECR repositories.
 
+locals {
+  default_tag_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Quickly expire untagged images"
+
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Retain at most 10 images"
+
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
 # First, create a custom Drupal container repository. This will house our built Drupal
 # images.
 resource "aws_ecr_repository" "drupal" {
@@ -8,6 +44,14 @@ resource "aws_ecr_repository" "drupal" {
   name = "webcms-${var.environment}-${each.key}-drupal"
 
   tags = var.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "drupal" {
+  for_each = toset(var.sites)
+
+  repository = aws_ecr_repository.drupal[each.key].name
+
+  policy = local.default_tag_policy
 }
 
 # Second, we also create an nginx repository. We do this for two reasons:
@@ -21,6 +65,14 @@ resource "aws_ecr_repository" "nginx" {
   tags = var.tags
 }
 
+resource "aws_ecr_lifecycle_policy" "nginx" {
+  for_each = toset(var.sites)
+
+  repository = aws_ecr_repository.nginx[each.key].name
+  
+  policy = local.default_tag_policy
+}
+
 # Create a custom Drush container repo
 resource "aws_ecr_repository" "drush" {
   for_each = toset(var.sites)
@@ -28,6 +80,14 @@ resource "aws_ecr_repository" "drush" {
   name = "webcms-${var.environment}-${each.key}-drush"
 
   tags = var.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "drush" {
+  for_each = toset(var.sites)
+
+  repository = aws_ecr_repository.drush[each.key].name
+
+  policy = local.default_tag_policy
 }
 
 # Finally, we create a cache repository for Kaniko-based builds. This repository has some

--- a/terraform/infrastructure/ecr.tf
+++ b/terraform/infrastructure/ecr.tf
@@ -69,7 +69,7 @@ resource "aws_ecr_lifecycle_policy" "nginx" {
   for_each = toset(var.sites)
 
   repository = aws_ecr_repository.nginx[each.key].name
-  
+
   policy = local.default_tag_policy
 }
 


### PR DESCRIPTION
This PR adds two lifecycle rules to each major ECR repository:

1. Any untagged image is expired within 24 hours, and
2. At most 10 tagged images are retained.