### PR TITLE
EPAD8-2412: Make Drush run as a non-root user

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -294,11 +294,6 @@ RUN \
 COPY scripts/ecs/drush-migrate.sh /usr/local/bin/drush-migrate
 RUN chmod +x /usr/local/bin/drush-migrate
 
-# Replace the default crontab with one that runs Drush every five minutes. By
-# default, cron is not run (since there is no systemd equivalent in containers),
-# but we use this in the Drush ECS service definition.
-RUN echo '*/5 * * * * drush cron --uri="${WEBCMS_SITE_URL}" 2>&1' | crontab -
-
 # Wrap the entrypoint script with tini to allow graceful signal handling
 ENTRYPOINT ["tini", "--", "docker-php-entrypoint"]
 
@@ -308,3 +303,6 @@ ARG GIT_TAG=""
 ARG GIT_COMMIT=""
 
 ENV GIT_TAG=${GIT_TAG} GIT_COMMIT=${GIT_COMMIT}
+
+# Lower user
+USER www-data


### PR DESCRIPTION
This PR modifies the Drush container in order to run as a non-root user. The new `USER` directive at the bottom of the Dockerfile is what accomplishes this; it embeds metadata that scanners can pick up:

```
$ docker build services/drupal --target drush --tag epa-drush
[snip]

$ docker inspect epa-drush | jq '.[0].Config.User'
"www-data"
```

In order to accommodate this change, we had to replace the `crond`-based scheduling. Alpine Linux (our base distribution) uses Busybox cron, which opens with this comment (see [crond.c](https://git.busybox.net/busybox/tree/miscutils/crond.c?h=1_36_1#n3)):

```c
/*
 * run as root, but NOT setuid root
 *
```

I experimented with trying a few workarounds, but couldn't get anywhere. The container itself doesn't really have any sophisticated scheduling needs: Ultimate Cron handles that within PHP, so we simply hammer it once a minute and let the module sort out what tasks, if any, need to run. (We use one-minute intervals in order to avoid a long-running PHP script slipping past the 5-minute mark and messing up any time-based calculations.)

Ultimately, this shouldn't result in any user-visible changes: Most of our tasks are scheduled aggressively enough that they should catch up within about thirty minutes.