### PR TITLE
Epad8 2250 hidden elements in homepage banners cannot be focused 

### DIFF
--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
@@ -42,6 +42,7 @@
   &[aria-hidden="true"] a,
   &[aria-hidden="true"] button {
     pointer-events: none;
+    visibility: hidden;
   }
 }
 

--- a/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
+++ b/services/drupal/web/themes/epa_theme/source/_patterns/05-components/hero-slideshow/_hero-slideshow.scss
@@ -38,6 +38,11 @@
       display: none;
     }
   }
+
+  &[aria-hidden="true"] a,
+  &[aria-hidden="true"] button {
+    pointer-events: none;
+  }
 }
 
 .hero-slideshow__nav {


### PR DESCRIPTION
uses css to make it so that links in hidden homepage slides cannot be tabbed to 