### PR TITLE
EPAD8-2513: Allow RSS feeds

### DIFF
--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -60,6 +60,49 @@ server {
     try_files /fast-404.html =404;
   }
 
+  # Exemptions to the below: we need to allow the RSS feed paths for various
+  # search pages.
+  location = /newsreleases/search/rss {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  # Also allow the trailing-slash variant
+  location = /newsreleases/search/rss/ {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /faqs/search/rss {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /faqs/search/rss/ {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /publicnotices/notices-search/rss {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /publicnotices/notices-search/rss/ {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /perspectives/search/rss {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /perspectives/search/rss/ {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /speeches/search/rss {
+    try_files $uri $uri/ @rewrite;
+  }
+
+  location = /speeches/search/rss/ {
+    try_files $uri $uri/ @rewrite;
+  }
+
   # For each listed path, return HTTP 410 Gone, using our 404 template instead:
   # users will see a "page not found" page, but code will see a "this page will
   # never return" status code. Hopefully this will defray some of the ongoing
@@ -88,7 +131,6 @@ server {
     error_page 410 /_404;
     return 410;
   }
-
 
   # This prevents nginx's view of the filesystem from conflicting with the Drupal node of
   # the same name.


### PR DESCRIPTION
This PR updates the nginx configuration to allow the `/rss` and `/rss/` subpaths to be subject to normal processing, before the HTTP 410 Gone blocks apply.