### PR TITLE
[EPAD8-2545] Adjusting userLogin() method of custom SSOController to return correct RedirectResponse as the Response::create method has been removed

### DIFF
--- a/services/drupal/web/modules/custom/f1_sso/src/Controller/SSOController.php
+++ b/services/drupal/web/modules/custom/f1_sso/src/Controller/SSOController.php
@@ -54,7 +54,7 @@ class SSOController extends ControllerBase {
       'destination' => $destination_url,
     ]);
 
-    return RedirectResponse::create($destination->toString());
+    return new RedirectResponse($destination->toString());
   }
 
 }


### PR DESCRIPTION
 see [https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpFoundation/CHANGELOG.md#60](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpFoundation/CHANGELOG.md#60).