### PR TITLE
Saving work to fix Can Publish button in group member dashboard

### DIFF
--- a/services/drupal/config/sync/views.view.group_members.yml
+++ b/services/drupal/config/sync/views.view.group_members.yml
@@ -786,17 +786,9 @@ display:
             default_group_multiple: {  }
             group_items:
               1:
-                title: 'Can publish'
+                title: 'Can publish?'
                 operator: regular_expression
                 value: ^(web_area-administrator|web_area-editor|web_area-approver)$
-              2:
-                title: ''
-                operator: '='
-                value: ''
-              3:
-                title: ''
-                operator: '='
-                value: ''
       filter_groups:
         operator: AND
         groups:

--- a/services/drupal/web/themes/epa_claro/css/styles.css
+++ b/services/drupal/web/themes/epa_claro/css/styles.css
@@ -113,3 +113,9 @@
   background: #003ecc;
 }
 
+.view-id-group_members .views-exposed-form__item.views-exposed-form__item.views-exposed-form__item--actions {
+  margin: var(--line-height-form-label);
+}
+.view-id-group_members .views-exposed-form.views-exposed-form {
+  padding: var(--space-xs) var(--space-s);
+}


### PR DESCRIPTION
Adjusted two files to tighten up the "can publish?" button on the group member dashboard