### PR TITLE
Updated allowed formats plugin

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -166,7 +166,7 @@
         "drupal/address_formatter": "^2.1@alpha",
         "drupal/addtocal": "^3.0@beta",
         "drupal/admin_toolbar": "^3.6",
-        "drupal/allowed_formats": "^2.0",
+        "drupal/allowed_formats": "^3.0",
         "drupal/anchor": "^1.0",
         "drupal/anchor_link": "~3.0",
         "drupal/auto_entitylabel": "^3.0",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "218a2bacfdcedff00edca857c8b1d097",
+    "content-hash": "84c41643aaffe13ce6f523a44eba3cc2",
     "packages": [
         {
             "name": "algolia/places",
@@ -2359,26 +2359,29 @@
         },
         {
             "name": "drupal/allowed_formats",
-            "version": "2.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/allowed_formats.git",
-                "reference": "2.0.0"
+                "reference": "3.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/allowed_formats-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "ac6c6d398f303608ced7e9cd9d4556a728dc41f0"
+                "url": "https://ftp.drupal.org/files/projects/allowed_formats-3.0.1.zip",
+                "reference": "3.0.1",
+                "shasum": "9dfaed3ab8425ee94146914fdb492cefc6c6bb4d"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^10.1 || ^11"
+            },
+            "conflict": {
+                "drupal/core": "<10.1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1669170410",
+                    "version": "3.0.1",
+                    "datestamp": "1723158950",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2411,7 +2414,7 @@
                     "role": "Maintainer"
                 }
             ],
-            "description": "Limit which text formats are available for each field instance.",
+            "description": "Hides info about the selected text format. The 'allowed formats' functionality has been moved to core since Drupal 10.1.0.",
             "homepage": "https://www.drupal.org/project/allowed_formats",
             "support": {
                 "source": "http://cgit.drupalcode.org/allowed_formats",

--- a/services/drupal/config/sync/core.extension.yml
+++ b/services/drupal/config/sync/core.extension.yml
@@ -10,7 +10,6 @@ module:
   address_formatter: 0
   addtocal: 0
   admin_toolbar: 0
-  admin_toolbar_links_access_filter: 0
   admin_toolbar_search: 0
   admin_toolbar_tools: 0
   allowed_formats: 0
@@ -117,8 +116,6 @@ module:
   image_style_quality: 0
   inline_entity_form: 0
   jquery_ui: 0
-  jquery_ui_autocomplete: 0
-  jquery_ui_menu: 0
   js_cookie: 0
   key: 0
   language: 0

--- a/services/drupal/config/sync/field.field.block_content.custom_html.body.yml
+++ b/services/drupal/config/sync/field.field.block_content.custom_html.body.yml
@@ -5,19 +5,15 @@ dependencies:
   config:
     - block_content.type.custom_html
     - field.storage.block_content.body
+    - filter.format.filtered_html
+    - filter.format.full_html
+    - filter.format.inline
+    - filter.format.plain_text
+    - filter.format.restricted_html
+    - filter.format.restricted_html_no_links
+    - filter.format.unprocessed
   module:
-    - allowed_formats
     - text
-third_party_settings:
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
-      - inline
-      - restricted_html
-      - restricted_html_no_links
-      - unprocessed
-      - plain_text
 id: block_content.custom_html.body
 field_name: body
 entity_type: block_content
@@ -31,5 +27,12 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
-  allowed_formats: {  }
+  allowed_formats:
+    - filtered_html
+    - full_html
+    - inline
+    - restricted_html
+    - restricted_html_no_links
+    - unprocessed
+    - plain_text
 field_type: text_with_summary

--- a/services/drupal/config/sync/field.field.media.remote_video.field_caption.yml
+++ b/services/drupal/config/sync/field.field.media.remote_video.field_caption.yml
@@ -4,18 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.media.field_caption
+    - filter.format.inline
     - media.type.remote_video
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - inline
 id: media.remote_video.field_caption
 field_name: field_caption
 entity_type: media
@@ -26,5 +23,7 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - inline
 field_type: text_long

--- a/services/drupal/config/sync/field.field.node.faq.body.yml
+++ b/services/drupal/config/sync/field.field.node.faq.body.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.body
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.faq
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.faq.body
 field_name: body
 entity_type: node
@@ -30,4 +27,7 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_with_summary

--- a/services/drupal/config/sync/field.field.node.public_notice.body.yml
+++ b/services/drupal/config/sync/field.field.node.public_notice.body.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.body
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.public_notice
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.public_notice.body
 field_name: body
 entity_type: node
@@ -30,4 +27,7 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_with_summary

--- a/services/drupal/config/sync/field.field.node.public_notice.field_how_to_comment.yml
+++ b/services/drupal/config/sync/field.field.node.public_notice.field_how_to_comment.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_how_to_comment
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.public_notice
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.public_notice.field_how_to_comment
 field_name: field_how_to_comment
 entity_type: node
@@ -30,5 +27,8 @@ default_value:
     value: "<p>You may comment on the proposed action in writing, using Email, Phone or mail. Submit comments to:</p>\r\n\r\n<p>Email:</p>\r\n\r\n<p>Phone:</p>\r\n\r\n<p>Mail:</p>\r\n"
     format: filtered_html
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.node.regulation.field_additional_resources.yml
+++ b/services/drupal/config/sync/field.field.node.regulation.field_additional_resources.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_additional_resources
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.regulation
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.regulation.field_additional_resources
 field_name: field_additional_resources
 entity_type: node
@@ -27,5 +24,8 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.node.regulation.field_compliance.yml
+++ b/services/drupal/config/sync/field.field.node.regulation.field_compliance.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_compliance
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.regulation
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.regulation.field_compliance
 field_name: field_compliance
 entity_type: node
@@ -27,5 +24,8 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.node.regulation.field_rule_history.yml
+++ b/services/drupal/config/sync/field.field.node.regulation.field_rule_history.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_rule_history
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.regulation
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.regulation.field_rule_history
 field_name: field_rule_history
 entity_type: node
@@ -27,5 +24,8 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.node.regulation.field_rule_summary.yml
+++ b/services/drupal/config/sync/field.field.node.regulation.field_rule_summary.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_rule_summary
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.regulation
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.regulation.field_rule_summary
 field_name: field_rule_summary
 entity_type: node
@@ -27,5 +24,8 @@ required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.node.web_area.field_aside_block.yml
+++ b/services/drupal/config/sync/field.field.node.web_area.field_aside_block.yml
@@ -4,19 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_aside_block
+    - filter.format.filtered_html
+    - filter.format.full_html
     - node.type.web_area
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
-      - full_html
 id: node.web_area.field_aside_block
 field_name: field_aside_block
 entity_type: node
@@ -27,5 +24,8 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.author.field_biography.yml
+++ b/services/drupal/config/sync/field.field.paragraph.author.field_biography.yml
@@ -4,18 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_biography
+    - filter.format.inline
     - paragraphs.paragraphs_type.author
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - inline
 id: paragraph.author.field_biography
 field_name: field_biography
 entity_type: paragraph
@@ -26,5 +23,7 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - inline
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.banner_slide.field_text.yml
+++ b/services/drupal/config/sync/field.field.paragraph.banner_slide.field_text.yml
@@ -4,15 +4,12 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_text
+    - filter.format.filtered_html
     - paragraphs.paragraphs_type.banner_slide
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
-  allowed_formats:
-    allowed_formats:
-      - filtered_html
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
@@ -27,5 +24,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  allowed_formats: {  }
+  allowed_formats:
+    - filtered_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.before_after_swipe_component.field_slider_caption.yml
+++ b/services/drupal/config/sync/field.field.paragraph.before_after_swipe_component.field_slider_caption.yml
@@ -4,18 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_slider_caption
+    - filter.format.restricted_html
     - paragraphs.paragraphs_type.before_after_swipe_component
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - restricted_html
 id: paragraph.before_after_swipe_component.field_slider_caption
 field_name: field_slider_caption
 entity_type: paragraph
@@ -26,5 +23,7 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - restricted_html
 field_type: text

--- a/services/drupal/config/sync/field.field.paragraph.card.field_body.yml
+++ b/services/drupal/config/sync/field.field.paragraph.card.field_body.yml
@@ -4,18 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_body
+    - filter.format.restricted_html_no_links
     - paragraphs.paragraphs_type.card
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - restricted_html_no_links
 id: paragraph.card.field_body
 field_name: field_body
 entity_type: paragraph
@@ -26,5 +23,7 @@ required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - restricted_html_no_links
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.html.field_body.yml
+++ b/services/drupal/config/sync/field.field.paragraph.html.field_body.yml
@@ -4,17 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_body
+    - filter.format.ckeditor_5_test
+    - filter.format.filtered_html
+    - filter.format.full_html
     - paragraphs.paragraphs_type.html
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
-  allowed_formats:
-    allowed_formats:
-      - ckeditor_5_test
-      - filtered_html
-      - full_html
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
@@ -29,5 +26,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  allowed_formats: {  }
+  allowed_formats:
+    - ckeditor_5_test
+    - filtered_html
+    - full_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.media_block.field_body.yml
+++ b/services/drupal/config/sync/field.field.paragraph.media_block.field_body.yml
@@ -4,15 +4,12 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_body
+    - filter.format.restricted_html
     - paragraphs.paragraphs_type.media_block
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
-  allowed_formats:
-    allowed_formats:
-      - restricted_html
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
@@ -26,5 +23,7 @@ required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - restricted_html
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.slide.field_caption.yml
+++ b/services/drupal/config/sync/field.field.paragraph.slide.field_caption.yml
@@ -4,18 +4,15 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_caption
+    - filter.format.inline
     - paragraphs.paragraphs_type.slide
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
-  allowed_formats:
-    allowed_formats:
-      - inline
 id: paragraph.slide.field_caption
 field_name: field_caption
 entity_type: paragraph
@@ -26,5 +23,7 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - inline
 field_type: text_long

--- a/services/drupal/config/sync/field.field.paragraph.tagline.field_text.yml
+++ b/services/drupal/config/sync/field.field.paragraph.tagline.field_text.yml
@@ -4,15 +4,12 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_text
+    - filter.format.restricted_html
     - paragraphs.paragraphs_type.tagline
   module:
-    - allowed_formats
     - custom_add_another
     - text
 third_party_settings:
-  allowed_formats:
-    allowed_formats:
-      - restricted_html
   custom_add_another:
     custom_add_another: ''
     custom_remove: ''
@@ -26,5 +23,7 @@ required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats:
+    - restricted_html
 field_type: text_long

--- a/services/drupal/web/modules/custom/epa_core/epa_core.info.yml
+++ b/services/drupal/web/modules/custom/epa_core/epa_core.info.yml
@@ -1,7 +1,7 @@
 name: 'EPA Core'
 description: Provides custom functionality for EPA.gov.
 type: module
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement:  ^9 || ^10 || ^11
 package: EPA
 dependencies:
   - drupal:taxonomy

--- a/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.info.yml
+++ b/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.info.yml
@@ -1,7 +1,7 @@
 name: 'EPA Web Areas'
 description: Custom functionality related to EPA's Web Areas.
 type: module
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 package: EPA
 dependencies:
   - drupal:views
@@ -10,4 +10,4 @@ dependencies:
   - group_outsider_in:group_outsider_in
   - page_manager:page_manager
   - pathauto:pathauto
-  - admin_toolbar:admin_toolbar_links_access_filter
+  

--- a/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
+++ b/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
@@ -110,11 +110,11 @@ function epa_web_areas_preprocess_menu(&$variables) {
     $original_link = $first_link['original_link'];
     $variables['menu_name'] = $original_link->getMenuName();
   }
-  if ($variables['menu_name'] == 'admin') {
-    if (admin_toolbar_links_access_filter_user_has_admin_role($variables['user'])) {
-      admin_toolbar_links_access_filter_filter_non_accessible_links($variables['items']);
-    }
-  }
+//  if ($variables['menu_name'] == 'admin') {
+//    if (admin_toolbar_links_access_filter_user_has_admin_role($variables['user'])) {
+//      admin_toolbar_links_access_filter_filter_non_accessible_links($variables['items']);
+//    }
+//  }
 }
 
 /**


### PR DESCRIPTION
Of note, this update removed multiple config sync items, including page_manager.page_variant.dashboard_overview-block_display-0.yml, and disabled the EPA Web Areas plugin. It might not have been the plugin updates, but rather the removal of Admin Toolbar Link Access