### PR TITLE
WEBCMS-53 update Entity Usage module (8.x-2.0-beta12 to 8.x-2.0-beta24)

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -212,7 +212,7 @@
         "drupal/entity_clone": "^2@beta",
         "drupal/entity_embed": "^1.5",
         "drupal/entity_reference_revisions": "^1.12",
-        "drupal/entity_usage": "^2.0-beta3",
+        "drupal/entity_usage": "^2.0@beta",
         "drupal/entitygroupfield": "^1.0.x-dev",
         "drupal/environment_indicator": "^4.0.21",
         "drupal/facets": "^2.0",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "072e87c190413b9589ee8cdaa3735e79",
+    "content-hash": "ca251d9dd004805cfca8fa2c9c465244",
     "packages": [
         {
             "name": "algolia/places",
@@ -5510,38 +5510,38 @@
         },
         {
             "name": "drupal/entity_usage",
-            "version": "2.0.0-beta12",
+            "version": "2.0.0-beta24",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_usage.git",
-                "reference": "8.x-2.0-beta12"
+                "reference": "8.x-2.0-beta24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta12.zip",
-                "reference": "8.x-2.0-beta12",
-                "shasum": "cdd31e6c413cad6fbdb1bd0aac9ad8a0331eb429"
+                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta24.zip",
+                "reference": "8.x-2.0-beta24",
+                "shasum": "063cf50d2b5cf7c99bb86a818c03fcfef2082151"
             },
             "require": {
-                "drupal/core": "^9.1 || ^10"
+                "drupal/core": "^10.2 || ^11"
             },
             "require-dev": {
                 "drupal/block_field": "~1.0",
-                "drupal/ckeditor": "^1.0",
                 "drupal/dynamic_entity_reference": "~1.0 || ^2.0 || ^4.0",
                 "drupal/entity_browser": "~2.0",
-                "drupal/entity_browser_block": "~1.0",
-                "drupal/entity_embed": "~1.0",
+                "drupal/entity_browser_block": "~1.0 || ^2.0",
+                "drupal/entity_embed": "^1.7",
                 "drupal/entity_reference_revisions": "~1.0",
-                "drupal/inline_entity_form": "^1.0@RC",
+                "drupal/inline_entity_form": "^1.0@RC || ^3.0@RC",
                 "drupal/paragraphs": "~1.0",
+                "drupal/redirect": "^1.11",
                 "drupal/webform": "^6.0.0-alpha4"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-beta12",
-                    "datestamp": "1684309054",
+                    "version": "8.x-2.0-beta24",
+                    "datestamp": "1743745774",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5559,11 +5559,15 @@
             ],
             "authors": [
                 {
+                    "name": "lullabot",
+                    "homepage": "https://www.drupal.org/user/3815489"
+                },
+                {
                     "name": "marcoscano",
                     "homepage": "https://www.drupal.org/user/1288796"
                 },
                 {
-                    "name": "seanB",
+                    "name": "seanb",
                     "homepage": "https://www.drupal.org/user/545912"
                 }
             ],
@@ -25284,6 +25288,7 @@
         "drupal/default_content": 15,
         "drupal/domain": 10,
         "drupal/entity_clone": 10,
+        "drupal/entity_usage": 10,
         "drupal/entitygroupfield": 20,
         "drupal/flag": 10,
         "drupal/flysystem": 10,

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca251d9dd004805cfca8fa2c9c465244",
+    "content-hash": "072e87c190413b9589ee8cdaa3735e79",
     "packages": [
         {
             "name": "algolia/places",

--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -74,9 +74,6 @@
     "drupal/config_ignore": {
       "Support for export filtering via Drush": "https://www.drupal.org/files/issues/2021-01-04/config_ignore_2857247-61.patch"
     },
-    "drupal/entity_usage": {
-      "Avoid errors when encountering empty data-* attributes": "https://www.drupal.org/files/issues/2020-09-30/3098733-7.patch"
-    },
     "drupal/autologout": {
       "Allow HTML in autologout messages": "patches/autologout-html-3367062.patch"
     },


### PR DESCRIPTION
I removed patch: https://www.drupal.org/files/issues/2020-09-30/3098733-7.patch. The issue the patch fixed (avoiding empty data-* attributes) is likely no longer applicable for version 8.x-2.0-beta24.