### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,15 +19,4 @@ updates:
     labels:
       - "dependencies"
       - "composer"
-      - "automated"
-  - package-ecosystem: "composer"
-    directory: "/services/drupal/web/modules/contrib/webform"
-    schedule:
-      interval: "weekly"
-    # This entry tells Dependabot to look at the webform module's
-    # composer.libraries.json file.
-  - package-ecosystem: "composer"
-    directory: "/services/drupal/web/modules/contrib/anchor_link"
-    schedule:
-      interval: "weekly"
-    # This entry tells Dependabot to look at the anchor_link dependencies.    
+      - "automated" 


### PR DESCRIPTION
Since the webform module is a Composer dependency, its code is not committed to your repository. Therefore, adding its directory to dependabot.yml will fail because Dependabot won't be able to find the file.