### PR TITLE
WEBCMS-154 update the Layout Builder iFrame from version 1.3.0 to 1.3.7

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -236,7 +236,7 @@
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/jquery_ui": "^1.8",
         "drupal/key": "^1.20",
-        "drupal/layout_builder_iframe_modal": "^1.0",
+        "drupal/layout_builder_iframe_modal": "^1.3",
         "drupal/layout_builder_modal": "^1.0",
         "drupal/layout_builder_restrictions": "^3.0",
         "drupal/layout_paragraphs": "^2.0",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8179d2f9a378945ef6bec6f2f5f7b5c",
+    "content-hash": "cebbb86686c29483aa45c44774163296",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7163,26 +7163,26 @@
         },
         {
             "name": "drupal/layout_builder_iframe_modal",
-            "version": "1.3.0",
+            "version": "1.3.7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_builder_iframe_modal.git",
-                "reference": "1.3.0"
+                "reference": "1.3.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/layout_builder_iframe_modal-1.3.0.zip",
-                "reference": "1.3.0",
-                "shasum": "c52c7c0ed91e747b49183dae911f6b640344fded"
+                "url": "https://ftp.drupal.org/files/projects/layout_builder_iframe_modal-1.3.7.zip",
+                "reference": "1.3.7",
+                "shasum": "45a636baf3cf5d9324b51b3f979c7dbdc0e6b97a"
             },
             "require": {
-                "drupal/core": "^8.8.0 || ^9.0 || ^10"
+                "drupal/core": "^10.1.3 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.3.0",
-                    "datestamp": "1671889303",
+                    "version": "1.3.7",
+                    "datestamp": "1756284869",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7202,6 +7202,10 @@
                 {
                     "name": "dulnan",
                     "homepage": "https://www.drupal.org/user/3652792"
+                },
+                {
+                    "name": "svendecabooter",
+                    "homepage": "https://www.drupal.org/user/35369"
                 }
             ],
             "description": "Render Laybout Builder block edit forms in an iframe, using the admin theme.",

--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -61,9 +61,6 @@
     "drupal/group_outsider_in": {
       "Automated Drupal 10 compatibility fixes" : "https://www.drupal.org/files/issues/2022-06-15/group_outsider_in.1.0-beta1.rector.patch"
     },
-    "drupal/layout_builder_iframe_modal": {
-      "Uncaught exception 'TypeError' with message 'Drupal\\layout_builder_iframe_modal\\IframeModalHelper::isModalRoute(): Argument #1 ($route_name) must be of type string, null given.": "https://git.drupalcode.org/project/layout_builder_iframe_modal/-/merge_requests/6.diff"
-    },
     "drupal/ckeditor_dev": {
       "Automated Drupal 11 compatibility fixes for ckeditor5_dev": "https://www.drupal.org/files/issues/2024-03-16/ckeditor5_dev.1.0.3.rector.patch"
     },


### PR DESCRIPTION
I removed this patch: https://git.drupalcode.org/project/layout_builder_iframe_modal/-/merge_requests/6.diff
Layout Builder iFrame: [https://jira.epa.gov/browse/WEBCMS-154](https://jira.epa.gov/browse/WEBCMS-154)

