### PR TITLE
WEBCMS-236 Update to s3fs 8.x-3.10 required for Drupal 10.6

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -268,7 +268,7 @@
         "drupal/riddler": "^3.0",
         "drupal/role_expose": "2.0.x-dev",
         "drupal/role_theme_switcher": "^1.2",
-        "drupal/s3fs": "^3.4",
+        "drupal/s3fs": "^3.10",
         "drupal/samlauth": "^3.11",
         "drupal/scheduled_publish": "^3.9",
         "drupal/schema_metatag": "^3.0",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ead9529ff962df7d42e4beccc1c0b148",
+    "content-hash": "09a5a4cd5961a8ef3bae327f44e4301a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9136,21 +9136,22 @@
         },
         {
             "name": "drupal/s3fs",
-            "version": "3.7.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/s3fs.git",
-                "reference": "8.x-3.7"
+                "reference": "8.x-3.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/s3fs-8.x-3.7.zip",
-                "reference": "8.x-3.7",
-                "shasum": "96fb481165bd330c05817958f3a1602a517c8267"
+                "url": "https://ftp.drupal.org/files/projects/s3fs-8.x-3.10.zip",
+                "reference": "8.x-3.10",
+                "shasum": "7728ff6428f74982a290f1888d4299077fcf0320"
             },
             "require": {
                 "aws/aws-sdk-php": "^3.18",
-                "drupal/core": "^8.8 || ^9 || ~10.0.0 || ~10.1.0 || ~10.2.0 || ~10.3.0 || ~10.4.0 || ~11.0.0 || ~11.1.0"
+                "drupal/core": ">=8.8 < 10.7 || >=11.0 < 11.2 || >=11.2.3 < 11.4",
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "drupal/key": "^1",
@@ -9167,8 +9168,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.7",
-                    "datestamp": "1734676879",
+                    "version": "8.x-3.10",
+                    "datestamp": "1768115550",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Closes WEBCMS-236

## Description

An update to drupal/s3fs from 8.x-3.7 to 8.x-3.10 to accommodate Drupal 10.6.2