### PR TITLE
Install Access Unpublished Group module version 1.0 from Drupal

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -162,6 +162,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "d3/d3": "^3.5",
         "drupal/access_unpublished": "^1.9",
+        "drupal/access_unpublished_group": "^1.0",
         "drupal/address": "^2.0",
         "drupal/address_formatter": "2.x-dev@dev",
         "drupal/addtocal": "^3.0@beta",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3973db3d67dcce688a03db956f204ced",
+    "content-hash": "f707b72dc23df8926f987a29f50d5e17",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2088,6 +2088,56 @@
             "homepage": "https://www.drupal.org/project/access_unpublished",
             "support": {
                 "source": "https://git.drupalcode.org/project/access_unpublished"
+            }
+        },
+        {
+            "name": "drupal/access_unpublished_group",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/access_unpublished_group.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/access_unpublished_group-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "8a7f52d2a7c19b06c7d05f55515049e2038b803f"
+            },
+            "require": {
+                "drupal/access_unpublished": "*",
+                "drupal/core": "^9 || ^10",
+                "drupal/group": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1764370648",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "dmundra",
+                    "homepage": "https://www.drupal.org/user/866436"
+                },
+                {
+                    "name": "mably",
+                    "homepage": "https://www.drupal.org/user/3375160"
+                }
+            ],
+            "description": "Supports using Access Unpublished with Group content.",
+            "homepage": "https://www.drupal.org/project/access_unpublished_group",
+            "support": {
+                "source": "https://git.drupalcode.org/project/access_unpublished_group"
             }
         },
         {
@@ -25136,12 +25186,12 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "ext-gd": "1.0.0",
         "ext-opcache": "1.0.0",
         "ext-pdo": "1.0.0",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Previously, we used the patch: https://git.drupalcode.org/project/access_unpublished/-/merge_requests/6.patch to implement the Access Unpublished Group functionality. 

The functionality is now available as a contributed module: https://www.drupal.org/project/access_unpublished_group. I have installed this module from Drupal.org and would like to push the changes to the development environment for testing.
