### PR TITLE
Add If around Inline media code.

### DIFF
--- a/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
+++ b/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
@@ -288,9 +288,11 @@ function _add_ckeditor5_settings(&$settings, mixed $setting, GroupInterface $gro
     }
 
     if ($key == 'drupalInlineMedia') {
-      $url = $value['libraryURL'];
-      $new_url = _media_library_opener_parameters_alter($url, $group);
-      $settings['editor']['formats'][$format]['editorSettings']['config'][$key]['libraryURL'] = $new_url;
+      if (isset($value['libraryURL'])) {
+        $url = $value['libraryURL'];
+        $new_url = _media_library_opener_parameters_alter($url, $group);
+        $settings['editor']['formats'][$format]['editorSettings']['config'][$key]['libraryURL'] = $new_url;
+      }
     }
 
     // Add group ID as query parameter for embeddedParagraph plugin.


### PR DESCRIPTION
https://jira.epa.gov/browse/WEBCMS-279

## Description

Adds a conditional around some Inline media code in epa webareas custom module that was throwing an error after removing the button. At some point once we know more about where all the code sits we can do more cleanup of old code. Once this conditional is in place the errors that Tom is working on will hit when saving entities.