### PR TITLE
Downgrade groupmedia to 8.x-2.1 on dev

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -230,7 +230,7 @@
         "drupal/group": "^1.2",
         "drupal/group_content_menu": "^1.0",
         "drupal/group_outsider_in": "^1.0-beta1",
-        "drupal/groupmedia": "^2.4",
+        "drupal/groupmedia": "^2.1",
         "drupal/hal": "~1.0.0 || ^2.0",
         "drupal/hierarchical_term_formatter": "^1.5",
         "drupal/honeypot": "2.1.4",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f707b72dc23df8926f987a29f50d5e17",
+    "content-hash": "77ba5f136f7cab50a35d77bc0eb74f13",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -25186,12 +25186,12 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "ext-gd": "1.0.0",
         "ext-opcache": "1.0.0",
         "ext-pdo": "1.0.0",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Closes WEBCMS-281 for development (need another PR for live)

## Description

Upgrading drupal/groupmedia to 8.x-2.4 was premature. See WEBCMS-274 for details