### PR TITLE
Disable ckeditor5 test and remove custom media inline embed button

### DIFF
--- a/services/drupal/config/sync/editor.editor.ckeditor_5_test.yml
+++ b/services/drupal/config/sync/editor.editor.ckeditor_5_test.yml
@@ -1,6 +1,6 @@
 uuid: 55ec41a6-7d01-4687-a4e7-992ba5ac761f
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - filter.format.ckeditor_5_test
@@ -33,7 +33,6 @@ settings:
       - abbreviation
       - link
       - anchor
-      - drupalInlineMedia
       - drupalMedia
       - paragraphs
       - epaNew
@@ -58,7 +57,6 @@ settings:
     ckeditor5_sourceEditing:
       allowed_tags:
         - '<article>'
-        - '<div>'
         - '<figure>'
         - '<figcaption>'
         - '<dl>'
@@ -117,7 +115,7 @@ settings:
         - '<embed src type width height>'
         - '<object form name type usemap width height>'
         - '<param name value>'
-        - '<iframe allowfullscreen sandbox scrolling seamless srcdoc>'
+        - '<iframe sandbox scrolling seamless srcdoc>'
         - '<video autoplay buffered controls crossorigin loop muted played preload poster src width height>'
         - '<audio autoplay buffered controls loop muted played preloadsrc>'
         - '<source media src type>'
@@ -211,9 +209,6 @@ settings:
         - 'data-*'
         - name
         - hidden
-    linkit_extension:
-      linkit_enabled: true
-      linkit_profile: default
     media_library_inlineMediaLibrary:
       allow_view_mode_override: true
     media_media:

--- a/services/drupal/config/sync/editor.editor.filtered_html.yml
+++ b/services/drupal/config/sync/editor.editor.filtered_html.yml
@@ -31,12 +31,10 @@ settings:
       - '|'
       - link
       - anchor
-      - drupalInlineMedia
       - '|'
       - drupalMedia
       - paragraphs
       - epaNew
-      - epaAddDefinition
       - iframeEmbed
       - htmlEmbed
       - '|'
@@ -223,8 +221,6 @@ settings:
     linkit_extension:
       linkit_enabled: true
       linkit_profile: default
-    media_library_inlineMediaLibrary:
-      allow_view_mode_override: true
     media_media:
       allow_view_mode_override: true
 image_upload:

--- a/services/drupal/config/sync/filter.format.ckeditor_5_test.yml
+++ b/services/drupal/config/sync/filter.format.ckeditor_5_test.yml
@@ -1,6 +1,6 @@
 uuid: d45cb726-a353-4fe3-922c-401b6fff8463
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_view_mode.media.large
@@ -72,7 +72,7 @@ filters:
     status: true
     weight: -49
     settings:
-      allowed_html: '<a id target rel class="ck-anchor" hreflang occurrence href aria-label data-entity-type data-entity-uuid data-entity-substitution> <br> <p> <h2 class="highlight"> <h3 class="highlight"> <h4 class="highlight"> <h5 class="highlight"> <h6 class="highlight"> <table class="usa-table usa-table--striped usa-table--unstyled usa-table--borderless usa-table--stacked usa-table--stacked-header" summary width height> <ul class="list list--clean list--pipeline list--roomy" type> <ol class="list list--roomy" type reversed start> <blockquote class="pull-quote u-align-left u-align-right" cite> <code class="code"> <mark class="mark"> <small class="small"> <span class="warning"> <article> <div> <figure> <figcaption> <dl> <dt> <dd> <address> <hgroup> <i> <b> <section> <cite> <dfn> <var> <samp> <kbd> <wbr> <bdi> <ruby> <rt> <rp> <summary> <legend> <datalist> <svg> <title> <q cite> <del cite datetime> <time datetime pubdate> <bdo dir> <colgroup span> <col span> <th headers scope width height rowspan colspan> <td headers scope width height rowspan colspan> <details open> <form action method> <fieldset disabled="disabled" form name> <label for form> <input checked="checked" size type value disabled="disabled" placeholder required readonly="readonly" autocomplete autofocus> <textarea rows cols disabled="disabled" placeholder required readonly="readonly" autocomplete autofocus> <meter min max low high optimum form value> <select multiple="multiple" size> <optgroup disabled="disabled" label> <option value> <output for form name> <button value> <keygen autofocus challenge disabled="disabled" form keytype name> <progress max value> <embed src type width height> <object form name type usemap width height> <param name value> <iframe allowfullscreen sandbox scrolling seamless srcdoc> <video autoplay buffered controls crossorigin loop muted played preload poster src width height> <audio autoplay buffered controls loop muted played preloadsrc> <source media src type> <track default kind label src srclang> <canvas width height> <map name> <area alt coords href hreflang media rel shape target type> <use href> <img alt crossorigin longdesc src usemap data-caption data-align width height data-entity-type data-entity-uuid> <strong> <em> <sub> <sup> <li> <hr> <tr> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <abbr title> <ins class="new" data-date> <drupal-inline-media data-entity-type data-entity-uuid alt data-view-mode> <drupal-paragraph data-embed-button data-entity-label data-paragraph-id data-paragraph-revision-id> <drupal-entity alt title data-align data-caption data-entity-embed-display data-entity-embed-display-settings data-view-mode data-entity-uuid data-langcode data-embed-button="node paragraphs" data-entity-type><* accesskey id class role aria-* tabindex title data data-* name hidden>'
+      allowed_html: '<a id target rel class="ck-anchor" hreflang occurrence href aria-label> <br> <p> <h2 class="highlight"> <h3 class="highlight"> <h4 class="highlight"> <h5 class="highlight"> <h6 class="highlight"> <table class="usa-table usa-table--striped usa-table--unstyled usa-table--borderless usa-table--stacked usa-table--stacked-header" summary width height> <ul class="list list--clean list--pipeline list--roomy" type> <ol class="list list--roomy" type reversed start> <blockquote class="pull-quote u-align-left u-align-right" cite> <code class="code"> <mark class="mark"> <small class="small"> <span class="warning"> <article> <figure> <figcaption> <dl> <dt> <dd> <address> <hgroup> <i> <b> <section> <cite> <dfn> <var> <samp> <kbd> <wbr> <bdi> <ruby> <rt> <rp> <summary> <legend> <datalist> <svg> <title> <q cite> <del cite datetime> <time datetime pubdate> <bdo dir> <colgroup span> <col span> <th headers scope width height rowspan colspan> <td headers scope width height rowspan colspan> <details open> <form action method> <fieldset disabled="disabled" form name> <label for form> <input checked="checked" size type value disabled="disabled" placeholder required readonly="readonly" autocomplete autofocus> <textarea rows cols disabled="disabled" placeholder required readonly="readonly" autocomplete autofocus> <meter min max low high optimum form value> <select multiple="multiple" size> <optgroup disabled="disabled" label> <option value> <output for form name> <button value> <keygen autofocus challenge disabled="disabled" form keytype name> <progress max value> <embed src type width height> <object form name type usemap width height> <param name value> <iframe sandbox scrolling seamless srcdoc> <video autoplay buffered controls crossorigin loop muted played preload poster src width height> <audio autoplay buffered controls loop muted played preloadsrc> <source media src type> <track default kind label src srclang> <canvas width height> <map name> <area alt coords href hreflang media rel shape target type> <use href> <img alt crossorigin longdesc src usemap data-caption data-align width height data-entity-type data-entity-uuid> <strong> <em> <sub> <sup> <li> <hr> <tr> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <abbr title> <ins class="new" data-date> <drupal-paragraph data-embed-button data-entity-label data-paragraph-id data-paragraph-revision-id> <drupal-entity alt title data-align data-caption data-entity-embed-display data-entity-embed-display-settings data-view-mode data-entity-uuid data-langcode data-embed-button="node paragraphs" data-entity-type><* accesskey id class role aria-* tabindex title data data-* name hidden>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:
@@ -124,6 +124,7 @@ filters:
     weight: -39
     settings:
       title: true
+      media_substitution: metadata
   media_embed:
     id: media_embed
     provider: media
@@ -134,9 +135,9 @@ filters:
       allowed_view_modes:
         large: large
         medium: medium
-        thumbnail: thumbnail
         original: original
         small: small
+        thumbnail: thumbnail
       allowed_media_types:
         audio: audio
         image: image
@@ -144,7 +145,7 @@ filters:
   media_inline_embed:
     id: media_inline_embed
     provider: media_inline_embed
-    status: true
+    status: false
     weight: -44
     settings:
       default_view_mode: link_with_metadata
@@ -154,8 +155,8 @@ filters:
         image: image
         other: other
       allowed_view_modes:
-        link_with_metadata: link_with_metadata
         link_with_description: link_with_description
+        link_with_metadata: link_with_metadata
   paragraphs_entity_embed:
     id: paragraphs_entity_embed
     provider: paragraphs_entity_embed

--- a/services/drupal/config/sync/filter.format.filtered_html.yml
+++ b/services/drupal/config/sync/filter.format.filtered_html.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.media.large
     - core.entity_view_mode.media.link_with_description
     - core.entity_view_mode.media.link_with_metadata
+    - core.entity_view_mode.media.media_library
     - core.entity_view_mode.media.medium
     - core.entity_view_mode.media.original
     - core.entity_view_mode.media.small
@@ -79,7 +80,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<a id target rel class="ck-anchor" hreflang occurrence href aria-label data-entity-type data-entity-uuid data-entity-substitution> <br> <p> <h2 class="highlight"> <h3 class="highlight"> <h4 class="highlight"> <h5 class="highlight"> <h6 class="highlight"> <blockquote class="pull-quote u-align-left u-align-right" cite> <ul class="list list--clean list--pipeline list--roomy" type> <ol class="list list--roomy" type reversed start> <span class="warning"> <mark class="mark"> <small class="small"> <table class="usa-table usa-table--striped usa-table--unstyled usa-table--borderless usa-table--stacked usa-table--stacked-header" summary width height> <article> <figure> <figcaption> <dl> <dt> <dd> <address> <hgroup> <i> <b> <section> <cite> <dfn> <var> <samp> <kbd> <wbr> <bdi> <ruby> <rt> <rp> <summary> <legend> <datalist> <map> <svg> <title> <q cite> <del cite datetime> <time datetime pubdate> <bdo dir> <colgroup span> <col span> <details open> <form action method> <fieldset disabled form> <label for form> <input checked size type value disabled placeholder required readonly autocomplete autofocus> <textarea rows cols disabled placeholder required readonly autocomplete autofocus> <meter min max low high optimum form value> <select multiple size> <optgroup disabled label> <option value> <output for form> <button value> <keygen autofocus challenge disabled form keytype> <progress max value> <img alt crossorigin height longdesc src width usemap> <embed height src type width> <object form height type usemap width> <param value> <iframe sandbox seamless srcdoc src height width name tabindex title allowfullscreen> <video autoplay buffered controls crossorigin height loop muted played preload poster src width> <audio autoplay buffered controls loop muted played preloadsrc> <source media src type> <track default kind label src srclang> <canvas height width> <area alt coords href hreflang media rel shape target type> <use href> <th headers height width rowspan colspan> <td headers scope width height rowspan colspan> <drupal-paragraph drupal-paragraph data-embed-button data-entity-label data-paragraph-id data-paragraph-revision-id> <strong> <em> <sub> <sup> <li> <hr> <tr> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <abbr title> <div class="raw-html-embed"> <ins class="new" data-date> <drupal-inline-media data-entity-type data-entity-uuid alt data-view-mode><* accesskey aria-* class id role tabindex title data data-* name hidden>'
+      allowed_html: '<a id target rel class="ck-anchor" hreflang occurrence href aria-label data-entity-type data-entity-uuid data-entity-substitution> <br> <p> <h2 class="highlight"> <h3 class="highlight"> <h4 class="highlight"> <h5 class="highlight"> <h6 class="highlight"> <blockquote class="pull-quote u-align-left u-align-right" cite> <ul class="list list--clean list--pipeline list--roomy" type> <ol class="list list--roomy" type reversed start> <span class="warning"> <mark class="mark"> <small class="small"> <table class="usa-table usa-table--striped usa-table--unstyled usa-table--borderless usa-table--stacked usa-table--stacked-header" summary width height> <article> <figure> <figcaption> <dl> <dt> <dd> <address> <hgroup> <i> <b> <section> <cite> <dfn> <var> <samp> <kbd> <wbr> <bdi> <ruby> <rt> <rp> <summary> <legend> <datalist> <map> <svg> <title> <q cite> <del cite datetime> <time datetime pubdate> <bdo dir> <colgroup span> <col span> <details open> <form action method> <fieldset disabled form> <label for form> <input checked size type value disabled placeholder required readonly autocomplete autofocus> <textarea rows cols disabled placeholder required readonly autocomplete autofocus> <meter min max low high optimum form value> <select multiple size> <optgroup disabled label> <option value> <output for form> <button value> <keygen autofocus challenge disabled form keytype> <progress max value> <img alt crossorigin height longdesc src width usemap> <embed height src type width> <object form height type usemap width> <param value> <iframe sandbox seamless srcdoc src height width name tabindex title allowfullscreen> <video autoplay buffered controls crossorigin height loop muted played preload poster src width> <audio autoplay buffered controls loop muted played preloadsrc> <source media src type> <track default kind label src srclang> <canvas height width> <area alt coords href hreflang media rel shape target type> <use href> <th headers height width rowspan colspan> <td headers scope width height rowspan colspan> <drupal-paragraph drupal-paragraph data-embed-button data-entity-label data-paragraph-id data-paragraph-revision-id> <strong> <em> <sub> <sup> <li> <hr> <tr> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <abbr title> <div class="raw-html-embed"> <ins class="new" data-date><* accesskey aria-* class id role tabindex title data data-* name hidden>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:
@@ -141,6 +142,7 @@ filters:
       default_view_mode: large
       allowed_view_modes:
         large: large
+        media_library: media_library
         medium: medium
         original: original
         small: small
@@ -152,7 +154,7 @@ filters:
   media_inline_embed:
     id: media_inline_embed
     provider: media_inline_embed
-    status: true
+    status: false
     weight: -45
     settings:
       default_view_mode: link_with_metadata


### PR DESCRIPTION
https://jira.epa.gov/browse/WEBCMS-280

## Description

Disables the ckeditor5 test text format and removes the custom media inline embed button from filtered html text format.
Also removes the Add definition button since it is breaking the editor. This should get the editor working again with a couple features wip.