### PR TITLE
WEBCMS-189 remove Views Ajax Get - no need to install this into the m…

### DIFF
--- a/services/drupal/web/modules/custom/epa_alerts/epa_alerts.info.yml
+++ b/services/drupal/web/modules/custom/epa_alerts/epa_alerts.info.yml
@@ -6,4 +6,3 @@ package: EPA
 dependencies:
   - token:token
   - pathauto:pathauto
-  - views_ajax_get:views_ajax_get


### PR DESCRIPTION
This functionality is now provided by Drupal core. There is no need to install this module from version 10.1.0 and onwards. See https://www.drupal.org/node/3193798. Required by the custom epa_alerts module