### PR TITLE
Update Editor Adv Link and Linkit to support core

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -201,7 +201,7 @@
         "drupal/devel": "^5.0",
         "drupal/diff": "^1.9",
         "drupal/duration_field": "^2.2",
-        "drupal/editor_advanced_link": "^2.3",
+        "drupal/editor_advanced_link": "2.3.x-dev@dev",
         "drupal/editoria11y": "^2.2",
         "drupal/elasticsearch_connector": "^7.0@alpha",
         "drupal/embed": "^1.10",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccd5657b431b3bdc4e67b9f42708fbcd",
+    "content-hash": "5ef81aee470168439f5f2d6210671c4e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4702,14 +4702,14 @@
         },
         {
             "name": "drupal/editor_advanced_link",
-            "version": "dev-2.x",
+            "version": "dev-2.3.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/editor_advanced_link.git",
-                "reference": "8fb5e79afe109763836cfdfd9aac7ec02e731785"
+                "reference": "b0ac4453401e4aaebd612a437e9dd9ba19e7c8f9"
             },
             "require": {
-                "drupal/core": "^10.2 || ^11.0"
+                "drupal/core": "^10.5 || ^11.2"
             },
             "require-dev": {
                 "drupal/ckeditor": "*",
@@ -4718,11 +4718,11 @@
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-2.x": "2.x-dev"
+                    "dev-2.3.x": "2.3.x-dev"
                 },
                 "drupal": {
-                    "version": "2.2.5+1-dev",
-                    "datestamp": "1744703551",
+                    "version": "2.3.3+2-dev",
+                    "datestamp": "1768801377",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -7544,17 +7544,17 @@
         },
         {
             "name": "drupal/linkit",
-            "version": "7.0.12",
+            "version": "7.0.14",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/linkit.git",
-                "reference": "7.0.12"
+                "reference": "7.0.14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/linkit-7.0.12.zip",
-                "reference": "7.0.12",
-                "shasum": "be60722e708e12be1596a804e816652c3c7ea815"
+                "url": "https://ftp.drupal.org/files/projects/linkit-7.0.14.zip",
+                "reference": "7.0.14",
+                "shasum": "b3a4025d1fcad688e716decffe808ad09b426931"
             },
             "require": {
                 "drupal/core": "^10.1 || ^11"
@@ -7562,8 +7562,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "7.0.12",
-                    "datestamp": "1765468273",
+                    "version": "7.0.14",
+                    "datestamp": "1777307887",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -25240,6 +25240,7 @@
         "drupal/content_moderation_revert": 20,
         "drupal/custom_add_another": 10,
         "drupal/default_content": 15,
+        "drupal/editor_advanced_link": 20,
         "drupal/elasticsearch_connector": 15,
         "drupal/entity_clone": 10,
         "drupal/entity_usage": 10,

--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -19,18 +19,18 @@
       "Improve layout builder performance by reducing number of calls to checkRequirements": "patches/drupal-layout-builder-performance-3186116-11.patch",
       "Add support for svgs in image fields": "https://www.drupal.org/files/issues/2022-06-23/drupal-responsive_image_svg_support-2957924-11.patch",
       "Revision tokens for content entities": "https://www.drupal.org/files/issues/2920310-04.patch",
-      "Improve format_size to support a precision parameter" : "https://www.drupal.org/files/issues/2024-06-28/2837979-25_0.patch",
-      "PoStreamReader::readLine() throws an error on module install" : "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch",
+      "Improve format_size to support a precision parameter": "https://www.drupal.org/files/issues/2024-06-28/2837979-25_0.patch",
+      "PoStreamReader::readLine() throws an error on module install": "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch",
       "PHP message: Error: Call to a member function getEntityTypeId() on null (Layout Builder)": "https://www.drupal.org/files/issues/2023-06-12/3049332-82.diff",
       "CKEditor 5 toolbar items of multi-value field (typically Paragraphs) overflowing on narrow viewports and overlapping with node form's sidebar on wide viewports": "https://www.drupal.org/files/issues/2025-03-26/drupal-ckeditor_paragraph_overflow_sidebar-3332416-100-d11.patch",
       "Allows hiding ajax errors": "https://www.drupal.org/files/issues/2024-02-05/2987444-53.patch",
       "Background colour of UI widgets get overridden on Ajax load.": "https://www.drupal.org/files/issues/2023-08-29/3383631-7_0.patch",
       "Provides a link to the latest revision": "https://www.drupal.org/files/issues/2025-02-20/2906455-45.patch",
-      ".ck-balloon-panel (link balloon, media balloon …) not visible for CKE5 instances in a Drupal dialog" : "https://www.drupal.org/files/issues/2024-04-02/cke-balloon-panel-tooltip-z-index-3351603-29.patch",
+      ".ck-balloon-panel (link balloon, media balloon …) not visible for CKE5 instances in a Drupal dialog": "https://www.drupal.org/files/issues/2024-04-02/cke-balloon-panel-tooltip-z-index-3351603-29.patch",
       "EPAD8-2672 Adjusting media library plugin button title": "patches/EPAD8-2672-media-library-src-only.patch"
     },
     "drupal/group": {
-     "Get a token of a node's parent group to create a pathauto pattern": "https://www.drupal.org/files/issues/2020-02-21/group-gnode_tokens-2774827-62.patch",
+      "Get a token of a node's parent group to create a pathauto pattern": "https://www.drupal.org/files/issues/2020-02-21/group-gnode_tokens-2774827-62.patch",
       "Node update hook is triggered upon group content create": "https://www.drupal.org/files/issues/2020-02-28/2872697-40-reroll-22.patch",
       "Fix user permissions on creating new content but not associating existing content": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch",
       "Ensure entity exists when deriving label": "https://www.drupal.org/files/issues/2020-03-03/group-3053524-14.patch",
@@ -49,7 +49,7 @@
       "Display media bundles in alpha order": "https://www.drupal.org/files/issues/2020-10-20/groupmedia-order_bundles-3178034-3.patch"
     },
     "drupal/group_outsider_in": {
-      "Automated Drupal 10 compatibility fixes" : "https://www.drupal.org/files/issues/2022-06-15/group_outsider_in.1.0-beta1.rector.patch"
+      "Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-06-15/group_outsider_in.1.0-beta1.rector.patch"
     },
     "drupal/ckeditor_dev": {
       "Automated Drupal 11 compatibility fixes for ckeditor5_dev": "https://www.drupal.org/files/issues/2024-03-16/ckeditor5_dev.1.0.3.rector.patch"
@@ -70,7 +70,7 @@
       "Fix integrity constraint violation when embedding paragraphs on blocks in layout builder": "https://www.drupal.org/files/issues/2023-07-20/2901390-9-109.patch",
       "Fixes paragraphs not rendering on current revision when they have been edited on forward revision": "https://www.drupal.org/files/issues/2020-07-08/access-controll-issue-3090200-22.patch",
       "Add paragraph button too large when using Claro admin theme": "https://www.drupal.org/files/issues/2024-03-13/add-paragraph-button-styles-claro-3424471-5.patch",
-      "Space missing between the word \"to\" and the emphasis tag near the add button" : "https://git.drupalcode.org/project/paragraphs/-/merge_requests/101.diff"
+      "Space missing between the word \"to\" and the emphasis tag near the add button": "https://git.drupalcode.org/project/paragraphs/-/merge_requests/101.diff"
     },
     "drupal/subpathauto": {
       "Shows page not found when url has encoded characters": "https://www.drupal.org/files/issues/shows_page_not_found-2865039-3.patch"
@@ -144,9 +144,9 @@
       "Patch diff interface to get language to match core patches in these issues: 3252521, 2899719, and 3252540": "patches/diff-patch-revision-language-to-match-3252521-2899719-3252540-3.patch",
       "Add classes to allow color-coding of revisions list": "https://www.drupal.org/files/issues/2021-12-03/diff-add_classes-3252547-2.patch"
     },
-    "drupal/entitygroupfield":  {
+    "drupal/entitygroupfield": {
       "Limit available groups in widget to ones user has permission to.": "https://www.drupal.org/files/issues/2020-08-07/entitygroupfield-Autocomplete_permissions-3163814-4.patch",
-      "Automated Drupal 10 compatibility fixes" : "https://www.drupal.org/files/issues/2023-08-18/entitygroupfield.1.0.x-dev.complete.v1.patch"
+      "Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2023-08-18/entitygroupfield.1.0.x-dev.complete.v1.patch"
     },
     "drupal/show_email": {
       "Fix config schema": "https://www.drupal.org/files/issues/2020-10-15/show_email-config_schema_issues-3177062-2.patch",
@@ -179,7 +179,7 @@
     },
     "drupal/access_unpublished": {
       "Support Group content": "https://git.drupalcode.org/project/access_unpublished/-/merge_requests/6.patch",
-      "Permission by role for generating a AU token" : "https://git.drupalcode.org/project/access_unpublished/-/merge_requests/14.diff"
+      "Permission by role for generating a AU token": "https://git.drupalcode.org/project/access_unpublished/-/merge_requests/14.diff"
     },
     "drupal/address_formatter": {
       "Add the 'canonical' link route template": "patches/address_formatter-canonical-3469118.patch"
@@ -192,6 +192,9 @@
     },
     "drupal/redirect_metrics": {
       "Issue #3556175: Use Database API in update 8100 to prevent timeouts": "patches/redirect_metrics-3556175-database-api-update.patch"
+    },
+    "drupal/editor_advanced_link": {
+      "Changing 'Displayed text' when creating a new link triggers JS error": "https://www.drupal.org/files/issues/2026-04-23/editor_advanced_link-3573993-ckeditor-v45-MR55_78a6c579.patch"
     }
   }
 }


### PR DESCRIPTION
Closes https://jira.epa.gov/browse/WEBCMS-299

## Description

Issue popped up when Mike was testing links in the latest core release 10.6.7. I updated Editor Advanced Link to the -dev version and added a patch. Also upped Linkit to the latest. 