### PR TITLE
Reset dev env deployment

### DIFF
--- a/services/drupal/README.md
+++ b/services/drupal/README.md
@@ -23,8 +23,7 @@ After that you can create the project:
 composer create-project drupal-composer/drupal-project:10.x-dev some-dir --no-interaction
 ```
 
-With `composer require ...` you can download new dependencies to your
-installation.
+With `composer require ...` you can download new dependencies to your installation.
 
 ```bash
 cd some-dir


### PR DESCRIPTION
Redeploy to development using the previous defaults. Views ajax get was uninstalled via UI it is causing an issue because of the EPA alerts custom module dependency.