### PR TITLE
Webcms 189

### DIFF
--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -27,7 +27,8 @@
       "Background colour of UI widgets get overridden on Ajax load.": "https://www.drupal.org/files/issues/2023-08-29/3383631-7_0.patch",
       "Provides a link to the latest revision": "https://www.drupal.org/files/issues/2025-02-20/2906455-45.patch",
       ".ck-balloon-panel (link balloon, media balloon …) not visible for CKE5 instances in a Drupal dialog": "https://www.drupal.org/files/issues/2024-04-02/cke-balloon-panel-tooltip-z-index-3351603-29.patch",
-      "EPAD8-2672 Adjusting media library plugin button title": "patches/EPAD8-2672-media-library-src-only.patch"
+      "EPAD8-2672 Adjusting media library plugin button title": "patches/EPAD8-2672-media-library-src-only.patch",
+      "Temporary dummy plugin to fix views_ajax_get WSOD on dev": "patches/dummy-views-ajax-get.patch"
     },
     "drupal/group": {
       "Get a token of a node's parent group to create a pathauto pattern": "https://www.drupal.org/files/issues/2020-02-21/group-gnode_tokens-2774827-62.patch",

--- a/services/drupal/config/sync/core.extension.yml
+++ b/services/drupal/config/sync/core.extension.yml
@@ -205,7 +205,6 @@ module:
   view_mode_select_by_token: 0
   view_modes_display: 0
   views: 0
-  views_ajax_get: 0
   views_autocomplete_filters: 0
   views_block_filter_block: 0
   views_bulk_operations: 0

--- a/services/drupal/config/sync/views.settings.yml
+++ b/services/drupal/config/sync/views.settings.yml
@@ -1,7 +1,6 @@
 _core:
   default_config_hash: RaRd9EIcwA4u3qCSRLL8EnCicbda1kV__ASmVbyehvQ
-display_extenders:
-  views_ajax_get: views_ajax_get
+display_extenders: {  }
 sql_signature: false
 ui:
   show:

--- a/services/drupal/patches/dummy-views-ajax-get.patch
+++ b/services/drupal/patches/dummy-views-ajax-get.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php b/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
+--- a/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
++++ b/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
+@@ -43,6 +43,10 @@ trait DiscoveryTrait {
+   protected function doGetDefinition(array $definitions, $plugin_id, $exception_on_invalid) {
+     // Avoid using a ternary that would create a copy of the array.
+     if (isset($definitions[$plugin_id])) {
+       return $definitions[$plugin_id];
+     }
++    // Temporary bypass: gracefully handle the removed views_ajax_get plugin.
++    if ($plugin_id === 'views_ajax_get') {
++      return NULL;
++    }
+     elseif (!$exception_on_invalid) {
+       return NULL;
+     }

--- a/services/drupal/patches/dummy-views-ajax-get.patch
+++ b/services/drupal/patches/dummy-views-ajax-get.patch
@@ -1,16 +1,15 @@
 diff --git a/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php b/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
 --- a/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
 +++ b/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
-@@ -43,6 +43,10 @@ trait DiscoveryTrait {
+@@ -43,6 +43,12 @@ trait DiscoveryTrait {
    protected function doGetDefinition(array $definitions, $plugin_id, $exception_on_invalid) {
++    // Temporary bypass: return the 'default' extender as a stand-in for the
++    // removed views_ajax_get plugin so the factory can instantiate something
++    // valid and the site does not crash.
++    if ($plugin_id === 'views_ajax_get') {
++      return isset($definitions['default']) ? $definitions['default'] : NULL;
++    }
      // Avoid using a ternary that would create a copy of the array.
      if (isset($definitions[$plugin_id])) {
        return $definitions[$plugin_id];
-     }
-+    // Temporary bypass: gracefully handle the removed views_ajax_get plugin.
-+    if ($plugin_id === 'views_ajax_get') {
-+      return NULL;
-+    }
-     elseif (!$exception_on_invalid) {
-       return NULL;
      }

--- a/services/drupal/patches/dummy-views-ajax-get.patch
+++ b/services/drupal/patches/dummy-views-ajax-get.patch
@@ -1,7 +1,11 @@
-diff --git a/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php b/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
---- a/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
-+++ b/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
-@@ -43,6 +43,12 @@ trait DiscoveryTrait {
+diff --git a/core/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php b/core/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
+index abcdef..123456 100644
+--- a/core/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
++++ b/core/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php
+@@ -40,8 +40,14 @@
+    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+    *   Thrown if $plugin_id is invalid and $exception_on_invalid is TRUE.
+    */
    protected function doGetDefinition(array $definitions, $plugin_id, $exception_on_invalid) {
 +    // Temporary bypass: return the 'default' extender as a stand-in for the
 +    // removed views_ajax_get plugin so the factory can instantiate something

--- a/services/drupal/web/modules/custom/epa_alerts/epa_alerts.libraries.yml
+++ b/services/drupal/web/modules/custom/epa_alerts/epa_alerts.libraries.yml
@@ -8,4 +8,3 @@ epaAlerts:
     - core/once
     - core/drupal.ajax
     - core/views.ajax
-    - views_ajax_get/ajax_get

--- a/services/drupal/web/modules/custom/epa_alerts/src/Plugin/Block/PublicAlertsBlock.php
+++ b/services/drupal/web/modules/custom/epa_alerts/src/Plugin/Block/PublicAlertsBlock.php
@@ -25,10 +25,6 @@ class PublicAlertsBlock extends BlockBase {
     $build['#alertContext'] = 'public';
 
     $build['#attached']['drupalSettings']['epaAlerts']['tomeEnabled'] = \Drupal::moduleHandler()->moduleExists('tome');
-    // Must manually add this since we're not directly rendering the view so the
-    // views_ajax_get module doesn't get an opportunity to attach it dynamically.
-    $build['#attached']['drupalSettings']['viewsAjaxGet']['public_alerts'] = 'public_alerts';
-
     $build['#attached']['drupalSettings']['epaAlerts']['context'] = 'public';
 
 


### PR DESCRIPTION
Closes https://jira.epa.gov/browse/WEBCMS-189

## Description

Removes Views Ajax Get contrib module and fixes the WSOD caused by uninstalling it via UI. The module uninstall is obviously buggy. This works by adding a core patch temporarily to get past the error. I will remove the patch after we get a clean installation. It also removes the dependency from epa_alerts.