### PR TITLE
Fix update:stage:es being skipped on every staging pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1094,9 +1094,12 @@ update:stage:en:
 update:stage:es:
   extends: .update
   stage: Update
-  needs:
-    - job: "deploy:stage:apply-es"
-      optional: true
+  # NOTE: No explicit `needs:` on `deploy:stage:apply-es`.
+  # That job is `when: manual` — if it's never clicked, an explicit
+  # `needs:` (even with `optional: true`) leaves this job blocked and
+  # ultimately marked as skipped at pipeline end. Relying on stage
+  # ordering (Update runs after Deploy:Stage:Apply) lets this job be
+  # triggered manually whether or not the apply was run.
   rules:
     - if: '$WEBCMS_SITE_FILTER && $WEBCMS_SITE_FILTER != "stage"'
       when: never
@@ -1114,6 +1117,7 @@ update:stage:es:
     name: site/stage-es
   # Temporary: Require manual approval during initial AWS testing
   when: manual
+
 update:dev:en:
   extends: .update
   stage: Update

--- a/ci/drush.js
+++ b/ci/drush.js
@@ -5,6 +5,7 @@ const dedent = require("dedent");
 const ecs = require("./ecs");
 const ui = require("./ui");
 const util = require("./util");
+const vars = require("./vars");
 
 /**
  * The Drush update script to run in ECS.
@@ -30,6 +31,33 @@ const drushScript = dedent`
  * @function
  */
 async function main() {
+  // Image-tag drift check. Compare the tag currently deployed in the ECS Drush task
+  // definition against the tag this CI build was produced from. A mismatch usually means
+  // the Drush update is being triggered without a fresh `deploy:*:apply-*` job (for
+  // example, when `update:stage:es` is run before `deploy:stage:apply-es` has been
+  // applied). This is advisory only — the Drush run continues either way.
+  ui.logHeading("ecs", "Verifying deployed image tag");
+
+  const deployedTag = await ecs.getDeployedImageTag();
+  if (!deployedTag) {
+    ui.log(
+      "⚠️  Could not determine the deployed image tag from ECS; skipping drift check."
+    );
+  } else if (deployedTag === vars.imageTag) {
+    ui.log(`Deployed tag matches build tag (${vars.imageTag}).`);
+  } else {
+    ui.log("⚠️  WARNING: Deployed image tag does not match this build's tag.");
+    ui.log(`    Build tag:    ${vars.imageTag}`);
+    ui.log(`    Deployed tag: ${deployedTag}`);
+    ui.log(
+      "    Drush will run against the currently-deployed image. If this is unexpected,"
+    );
+    ui.log(
+      `    re-run the corresponding deploy:${vars.site}:apply-${vars.lang} job first.`
+    );
+  }
+  ui.log();
+
   // Wipe the running Drupal tasks since they're most likely stale. See the documentation
   // for `stopRunningTasks` for why.
   ui.logHeading("ecs", "Stopping Drupal tasks");

--- a/ci/ecs.js
+++ b/ci/ecs.js
@@ -204,6 +204,55 @@ async function getDrushStatus(task) {
   return { stopCode, stopReason: stoppedReason, exitCode, exitReason: reason };
 }
 
+/**
+ * Fetches the image tag currently configured in the ACTIVE revision of the Drush task
+ * definition for this site/language. This is used by `drush.js` to detect drift between
+ * the build tag that triggered the Drush update and the image tag that is actually
+ * deployed in ECS — useful for catching cases where Drush is being run against a stale
+ * deployment (for example, when `update:stage:es` is triggered without first applying
+ * `deploy:stage:apply-es`).
+ *
+ * The returned string is the portion of the container image URL after the final `:`,
+ * which matches the convention used by `$WEBCMS_IMAGE_TAG` in `.gitlab-ci.yml`.
+ *
+ * Returns `undefined` (rather than throwing) when the tag cannot be determined, since
+ * this information is advisory only and the surrounding Drush run should not be blocked
+ * by a transient AWS error.
+ *
+ * @return {Promise<string | undefined>}
+ *
+ * @public
+ */
+async function getDeployedImageTag() {
+  const taskDefinition = `webcms-${vars.environment}-${vars.site}-${vars.lang}-drush`;
+
+  try {
+    const command = new ECS.DescribeTaskDefinitionCommand({ taskDefinition });
+    const response = await client.send(command);
+
+    const drushContainer = response.taskDefinition?.containerDefinitions?.find(
+      (c) => c.name === "drush"
+    );
+
+    if (!drushContainer || !drushContainer.image) {
+      return undefined;
+    }
+
+    // Image URLs are of the form `<registry>/<repo>:<tag>`. Split on the last `:` to
+    // tolerate registries that include a port (e.g., `host:5000/repo:tag`).
+    const lastColon = drushContainer.image.lastIndexOf(":");
+    if (lastColon === -1) {
+      return undefined;
+    }
+
+    return drushContainer.image.slice(lastColon + 1);
+  } catch {
+    // Advisory only — swallow errors so they don't abort the Drush run.
+    return undefined;
+  }
+}
+
 exports.stopRunningTasks = stopRunningTasks;
 exports.startDrushTask = startDrushTask;
 exports.getDrushStatus = getDrushStatus;
+exports.getDeployedImageTag = getDeployedImageTag;


### PR DESCRIPTION
Closes https://jira.epa.gov/browse/MOB-2143

## Description

Removes the needs: deploy:stage:apply-es block from update:stage:es in .gitlab-ci.yml. The dependency on a when: manual upstream was leaving the job blocked and ultimately marked as skipped — optional: true doesn't cover the present-but-unstarted case. The job now relies on stage ordering and remains gated by its existing rules: and manual trigger.

To preserve a safety signal, ci/drush.js now compares the deployed ECS Drush image tag against the current build tag and logs a non-fatal ⚠️ warning if they drift, so operators are alerted when running Drush against a stale deployment.

