### PR TITLE
Webcms 294 leaked cacheability metadata

### DIFF
--- a/services/drupal/web/modules/custom/f1_sso/f1_sso.module
+++ b/services/drupal/web/modules/custom/f1_sso/f1_sso.module
@@ -20,7 +20,18 @@ function f1_sso_user_login($account) {
 
   // Only overwrite destination if we don't already have one set.
   if (empty(\Drupal::service('request_stack')->getCurrentRequest()->query->get('destination'))) {
-    \Drupal::service('request_stack')->getCurrentRequest()->query->set('destination', '/admin/content/my-web-areas');
+    $url = \Drupal\Core\Url::fromUserInput('/admin/content/my-web-areas');
+    $generatedUrl = $url->toString(TRUE);
+
+    $cacheability = new Drupal\Core\Cache\CacheableMetadata();
+    $cacheability->setCacheContexts(['user.roles', 'url.query_args']);
+     
+    $response = new Drupal\Core\Routing\TrustedRedirectResponse($generatedUrl->getGeneratedUrl());
+    $response->addCacheableDependency($cacheability);
+
+
+    \Drupal::request()->query->set('destination', $generatedUrl->getGeneratedUrl());
+    \Drupal::service('request_stack')->getCurrentRequest()->attributes->set('_redirect', $response);
   }
 
 }

--- a/services/drupal/web/modules/custom/f1_sso/f1_sso.module
+++ b/services/drupal/web/modules/custom/f1_sso/f1_sso.module
@@ -21,6 +21,8 @@ function f1_sso_user_login($account) {
   // Only overwrite destination if we don't already have one set.
   if (empty(\Drupal::service('request_stack')->getCurrentRequest()->query->get('destination'))) {
     $url = \Drupal\Core\Url::fromUserInput('/admin/content/my-web-areas');
+    
+    //Generate absolute URL, setting to TRUE collect bubbleable metadata
     $generatedUrl = $url->toString(TRUE);
 
     $cacheability = new Drupal\Core\Cache\CacheableMetadata();


### PR DESCRIPTION
Closes https://jira.epa.gov/browse/WEBCMS-294

## Description

Fixes the issue where we see the error Error: While processing SAML authentication response, code leaked cacheability metadata when a user is logged in via SSO.

Use this section for review hints, explanations or discussion points/todos.

- The issue is reported in samlauth module known issues, https://www.drupal.org/project/samlauth/issues/3232577
- The fix is to avoid using destination parameter in hook_user_login without bubbling cacheability metadata
- There is one hook_user_login implementation in our custom module that modifies destination parameter and does not use   bubbling cacheability metadata
- This PR fixs this user login in f1_sso.module

