### PR TITLE
fix(drush): pin drush PHP image to 8.3 to match FPM stage

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -216,7 +216,9 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 
 # Build a drush-specific image: this image includes command-line utilities such as mysql
 # and ssh that are inappropriate for a server container image.
-FROM public.ecr.aws/docker/library/php:8.2-cli-alpine AS drush
+# IMPORTANT: keep this PHP version in sync with the base FPM image above so that Drush
+# and the web container run identical language semantics against the same Drupal codebase.
+FROM public.ecr.aws/docker/library/php:8.3-cli-alpine AS drush
 
 # Bump system packages
 RUN apk upgrade


### PR DESCRIPTION
The drush build stage was using `php:8.2-cli-alpine` while the FPM stage runs `php:8.3`. Both containers execute the same Drupal codebase, so a version mismatch can cause fatal errors when drush encounters PHP 8.3-only syntax, and masks dependency incompatibilities behind `--ignore-platform-reqs`.