### PR TITLE
refactor(nginx): extract shared FastCGI params into fastcgi-drupal.conf

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -201,7 +201,10 @@ COPY --from=drupal /var/www/html /var/www/html
 # Copy nginx configuration
 COPY status.conf *.map /etc/nginx/conf.d/
 
-# Copy configuration templates
+# Copy configuration templates and the shared FastCGI parameter snippet.
+# fastcgi-drupal.conf is referenced via `include fastcgi-drupal.conf` from
+# default.conf.template, so it must land in nginx's default search path.
+COPY fastcgi-drupal.conf /etc/nginx/
 COPY default.conf /etc/nginx/templates/default.conf.template
 
 # Copy nginx startup script

--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -60,90 +60,51 @@ server {
     try_files /fast-404.html =404;
   }
 
-  # These paths are exceptions to the search 410s that we have listed below.
+  # ---------------------------------------------------------------------------
+  # RSS feed endpoints — bypass the 410 rules below and pass straight to PHP.
+  #
+  # Each block only overrides the two parameters that differ from the shared
+  # fastcgi-drupal.conf include (PATH_INFO and SCRIPT_FILENAME). All other
+  # FastCGI parameters, buffer settings, and the upstream address are defined
+  # once in fastcgi-drupal.conf.
+  # ---------------------------------------------------------------------------
 
-  # Bypass rewrite statements and pass straight to PHP-FPM. Use the same FastCGI
-  # parameters as in the "main" block below.
   location = /newsreleases/search/rss {
-    # Hardcode PATH_INFO to the matched location instead of using fastcgi_split_path_info.
     fastcgi_param PATH_INFO /newsreleases/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi_params;
-    fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
-    fastcgi_param HTTPS on;
-    fastcgi_param HTTP_X_FORWARDED_PROTO https;
-    fastcgi_param REMOTE_ADDR $realip_remote_addr;
-    fastcgi_hide_header X-Powered-By;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
-    fastcgi_intercept_errors on;
-    fastcgi_pass localhost:9000;
+    include fastcgi-drupal.conf;
   }
 
   location = /faqs/search/rss {
     fastcgi_param PATH_INFO /faqs/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi_params;
-    fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
-    fastcgi_param HTTPS on;
-    fastcgi_param HTTP_X_FORWARDED_PROTO https;
-    fastcgi_param REMOTE_ADDR $realip_remote_addr;
-    fastcgi_hide_header X-Powered-By;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
-    fastcgi_intercept_errors on;
-    fastcgi_pass localhost:9000;
+    include fastcgi-drupal.conf;
   }
 
   location = /publicnotices/notices-search/rss {
     fastcgi_param PATH_INFO /publicnotices/notices-search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi_params;
-    fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
-    fastcgi_param HTTPS on;
-    fastcgi_param HTTP_X_FORWARDED_PROTO https;
-    fastcgi_param REMOTE_ADDR $realip_remote_addr;
-    fastcgi_hide_header X-Powered-By;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
-    fastcgi_intercept_errors on;
-    fastcgi_pass localhost:9000;
+    include fastcgi-drupal.conf;
   }
 
   location = /perspectives/search/rss {
     fastcgi_param PATH_INFO /perspectives/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi_params;
-    fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
-    fastcgi_param HTTPS on;
-    fastcgi_param HTTP_X_FORWARDED_PROTO https;
-    fastcgi_param REMOTE_ADDR $realip_remote_addr;
-    fastcgi_hide_header X-Powered-By;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
-    fastcgi_intercept_errors on;
-    fastcgi_pass localhost:9000;
+    include fastcgi-drupal.conf;
   }
 
   location = /speeches/search/rss {
     fastcgi_param PATH_INFO /speeches/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi_params;
-    fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
-    fastcgi_param HTTPS on;
-    fastcgi_param HTTP_X_FORWARDED_PROTO https;
-    fastcgi_param REMOTE_ADDR $realip_remote_addr;
-    fastcgi_hide_header X-Powered-By;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
-    fastcgi_intercept_errors on;
-    fastcgi_pass localhost:9000;
+    include fastcgi-drupal.conf;
   }
 
-  # For each listed path, return HTTP 410 Gone, using our 404 template instead:
-  # users will see a "page not found" page, but code will see a "this page will
-  # never return" status code. Hopefully this will defray some of the ongoing
-  # load.
+  # ---------------------------------------------------------------------------
+  # Return HTTP 410 Gone for high-traffic search paths that Drupal no longer
+  # serves. Using 410 (rather than 404) signals to crawlers that these URLs
+  # will never return, reducing ongoing load.
+  # ---------------------------------------------------------------------------
+
   location ^~ /newsreleases/search/ {
     error_page 410 /_404;
     return 410;
@@ -169,7 +130,6 @@ server {
     return 410;
   }
 
-
   # This prevents nginx's view of the filesystem from conflicting with the Drupal node of
   # the same name.
   location = /libraries {
@@ -180,51 +140,22 @@ server {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    include fastcgi_params;
-
-    # When an AWS ALB performs a health check against the Drupal ECS task, it uses the
-    # container's IP address for the Host header. If this health check is performed after
-    # a cache clear, then it's possible that Drupal will create aggregated CSS/JS or even
-    # a cached page that refers to that private IP (e.g., 10.x.y.z) instead of the site
-    # domain, rendering assets unusable.
-    # Normally, we would use trusted host headers here, but that would cause Drupal to
-    # reject the load balancer health check. A failed health check would cause it to be
-    # restarted by AWS, putting every container in an infinite loop.
-    # As a result, we instead force the value of HTTP_HOST to be the site's domain in all
-    # cases. Since the containers do not have public IP addresses, all HTTP Host header
-    # checks will be performed by the load balancer, filtering out malicious or
-    # misconfigured requests before they reach this point.
-    fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
-
-    # Drupal is always behind an HTTPS URL in AWS.
-    fastcgi_param HTTPS on;
-
-    # The SAML library checks this value instead of $_SERVER['HTTPS'], so we set it to
-    # agree with that variable.
-    fastcgi_param HTTP_X_FORWARDED_PROTO https;
-
-    # Replace REMOTE_ADDR with the forwarded IP from the load balancer
-    fastcgi_param REMOTE_ADDR $realip_remote_addr;
-
-    # Ignore PHP's X-Powered-By header
-    fastcgi_hide_header X-Powered-By;
-
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
-    fastcgi_intercept_errors on;
-
-    # Unlike docker-compose, in ECS, the Drupal and nginx containers are bound to the same
-    # network interface, meaning that they communicate with each other over localhost
-    # instead of different hostnames.
-    fastcgi_pass localhost:9000;
+    include fastcgi-drupal.conf;
   }
+
+  # ---------------------------------------------------------------------------
+  # S3 / CDN proxy locations.
+  #
+  # All proxy_pass blocks use 169.254.169.253 — the AWS VPC DNS resolver per
+  # https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html
+  # This is the correct resolver for ECS Fargate. The Docker embedded resolver
+  # (127.0.0.11) is not guaranteed to be present in Fargate tasks.
+  # ---------------------------------------------------------------------------
 
   location ~* ^/(s3fs-css|s3fs-js)/(.*) {
     set $s3_base_path $WEBCMS_S3_DOMAIN/files;
     set $file_path $2;
 
-    # Use the VPC's DNS server for resolution instead of the outside internet
-    # cf. https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html#AmazonDNS
     resolver 169.254.169.253 valid=30s;
     resolver_timeout 5s;
     expires max;
@@ -271,25 +202,29 @@ server {
     proxy_pass http://$WEBCMS_S3_DOMAIN/archive/;
   }
 
+  # ---------------------------------------------------------------------------
+  # Static asset caching
+  # ---------------------------------------------------------------------------
+
   # Add a max-age to static assets.
   location ~* \.(png|jpg|jpeg|gif|ico)$ {
-      try_files $uri @rewrite;
-      expires 10800;
+    try_files $uri @rewrite;
+    expires 10800;
   }
 
   location ~* \.(js|css)$ {
-      try_files $uri @rewrite;
-      expires 31536000;
+    try_files $uri @rewrite;
+    expires 31536000;
   }
 
-  # Need to handle SVGs separately since they need the CORS header.
-    location ~* \.(svg)$ {
-      add_header Access-Control-Allow-Origin "*";
-      expires 10800;
-      try_files $uri @rewrite;
-    }
+  # SVGs need a CORS header in addition to caching.
+  location ~* \.(svg)$ {
+    add_header Access-Control-Allow-Origin "*";
+    expires 10800;
+    try_files $uri @rewrite;
+  }
 
-  # Add an even longer max-age to fonts and allow them to be accessed cross-origin
+  # Fonts: long cache + cross-origin access.
   location ~* \.(woff2|woff|otf|ttf)$ {
     add_header Access-Control-Allow-Origin "*";
     expires 31536000;

--- a/services/drupal/fastcgi-drupal.conf
+++ b/services/drupal/fastcgi-drupal.conf
@@ -1,0 +1,49 @@
+# Shared FastCGI parameters for all PHP locations.
+#
+# Include this file from any location block that passes requests to PHP-FPM, then
+# add only the parameters that differ per location (typically PATH_INFO and
+# SCRIPT_FILENAME). For example:
+#
+#   location = /some/path {
+#     fastcgi_param PATH_INFO /some/path;
+#     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
+#     include fastcgi-drupal.conf;
+#   }
+#
+# Note: nginx processes all `fastcgi_param` directives in a location block before
+# the included file, so local definitions listed *before* this include will be
+# overridden here if the same key appears in fastcgi_params. To guarantee a local
+# value wins, list it *after* the include statement.
+
+include fastcgi_params;
+
+# Force HTTP_HOST to the configured site domain in all cases.
+# The AWS ALB health-check uses the container IP as Host; without this override
+# Drupal would occasionally cache pages or assets with the private IP, making
+# them unreachable from the public internet.
+fastcgi_param HTTP_HOST $WEBCMS_DOMAIN;
+
+# Drupal is always reached via HTTPS in AWS (TLS terminates at CloudFront/ALB).
+fastcgi_param HTTPS on;
+
+# The SAML library reads HTTP_X_FORWARDED_PROTO instead of HTTPS in some paths.
+fastcgi_param HTTP_X_FORWARDED_PROTO https;
+
+# Replace REMOTE_ADDR with the real client IP resolved from the X-Forwarded-For
+# header by the real_ip module (configured in the server block).
+fastcgi_param REMOTE_ADDR $realip_remote_addr;
+
+# Suppress the PHP version disclosure header.
+fastcgi_hide_header X-Powered-By;
+
+# Buffer tuning — keep in sync with the main PHP location block below.
+fastcgi_buffers 16 16k;
+fastcgi_buffer_size 32k;
+
+# Let nginx generate error responses for upstream FastCGI errors rather than
+# forwarding PHP's raw error output to the client.
+fastcgi_intercept_errors on;
+
+# nginx and PHP-FPM are co-located in the same ECS task and share a network
+# namespace, so they communicate over localhost.
+fastcgi_pass localhost:9000;


### PR DESCRIPTION
Five RSS endpoint locations in `default.conf` each repeated the same 10 FastCGI parameter lines. Any change to buffer sizes or the FPM upstream address required editing all five locations plus the main PHP block.\n\nConsolidate the shared parameters into a new `fastcgi-drupal.conf` snippet and replace each block with a two-line include. Only `PATH_INFO` and `SCRIPT_FILENAME` differ per location and remain inline.