### PR TITLE
fix(nginx): standardize S3 proxy DNS resolver to 169.254.169.253

### DIFF
--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -236,11 +236,11 @@ server {
   }
 
   location ^~ /sites/default/files/widgets/ {
-    resolver 127.0.0.11 valid=30s;
+    resolver 169.254.169.253 valid=30s;
     resolver_timeout 5s;
     expires 3600;
 
-     # S3 does *not* like http basic auth
+    # S3 does *not* like http basic auth
     proxy_set_header Authorization "";
 
     # Allow embedding widgets on other domains
@@ -250,22 +250,22 @@ server {
   }
 
   location ^~ /sites/default/files/ {
-    resolver 127.0.0.11 valid=30s;
+    resolver 169.254.169.253 valid=30s;
     resolver_timeout 5s;
     expires 3600;
 
-     # S3 does *not* like http basic auth
+    # S3 does *not* like http basic auth
     proxy_set_header Authorization "";
 
     proxy_pass http://$WEBCMS_S3_DOMAIN/files/;
   }
 
   location ^~ /archive/ {
-    resolver 127.0.0.11 valid=30s;
+    resolver 169.254.169.253 valid=30s;
     resolver_timeout 5s;
     expires 3600;
 
-     # S3 does *not* like http basic auth
+    # S3 does *not* like http basic auth
     proxy_set_header Authorization "";
 
     proxy_pass http://$WEBCMS_S3_DOMAIN/archive/;


### PR DESCRIPTION
The `sites/default/files/widgets`, `sites/default/files`, and `archive` proxy blocks were using `127.0.0.11` (Docker embedded DNS) while the `s3fs-css`/`s3fs-js` block already used `169.254.169.253` (AWS VPC DNS). The Docker resolver is not present in ECS Fargate tasks, so those three blocks fail to resolve S3 hostnames in production. Standardize all `proxy_pass` blocks to the VPC resolver.