### PR TITLE
fix(cloudwatch): add null guard in setLogStreamFromContainerMetadata

### DIFF
--- a/services/drupal/web/modules/custom/epa_cloudwatch/src/Logger/CloudWatch.php
+++ b/services/drupal/web/modules/custom/epa_cloudwatch/src/Logger/CloudWatch.php
@@ -205,7 +205,19 @@ class CloudWatch implements LoggerInterface {
     }
 
     // Use the Docker container ID as the stream name, same as the ECS logs agent.
-    $metadata = json_decode($json, FALSE, 512, JSON_THROW_ON_ERROR);
+    try {
+      $metadata = json_decode($json, FALSE, 512, JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException $e) {
+      // The metadata endpoint returned malformed JSON. Fall back gracefully
+      // rather than propagating a fatal error into the request.
+      return FALSE;
+    }
+
+    // Guard against a null decode result or a missing DockerId field.
+    if ($metadata === NULL || !isset($metadata->DockerId)) {
+      return FALSE;
+    }
 
     $this->logStream = $metadata->DockerId;
     return TRUE;


### PR DESCRIPTION
`json_decode` can return `null` for a valid JSON null payload, in which case accessing `$metadata->DockerId` throws a fatal `TypeError`. Wrap the decode in a `try/catch` for `JsonException` (malformed JSON) and add an explicit null check before accessing `DockerId`. Both failure paths return `FALSE` so the caller falls back gracefully rather than propagating an error into the request.