### PR TITLE
fix(ci): add environment guard and dry-run flag to cleanup-webforms

### DIFF
--- a/ci/cleanup-webforms.js
+++ b/ci/cleanup-webforms.js
@@ -1,12 +1,54 @@
 // @ts-check
-// One-time script to delete all webform submissions and webforms
-// This resolves config import conflicts when webforms have submissions
+// One-time script to delete all webform submissions and webforms.
+// This resolves config import conflicts when webforms have submissions.
+//
+// SAFETY GUARDS:
+//   1. WEBCMS_SITE must be "dev" — this script will refuse to run against stage or prod.
+//   2. Pass --dry-run to preview what would be deleted without touching the database.
+//
+// Usage:
+//   node cleanup-webforms.js            # Live run (dev only)
+//   node cleanup-webforms.js --dry-run  # Preview row counts, no deletes
 
 const ecs = require("./ecs");
 const ui = require("./ui");
 const util = require("./util");
+const vars = require("./vars");
 
-const cleanupScript = `
+// ---------------------------------------------------------------------------
+// Safety: hard-block execution on anything that is not the dev site.
+// ---------------------------------------------------------------------------
+if (vars.site !== "dev") {
+  console.error(
+    `ERROR: cleanup-webforms.js may only run against the dev site.\n` +
+    `  Current WEBCMS_SITE = "${vars.site}"\n` +
+    `  Refusing to proceed to protect stage and production data.`
+  );
+  process.exitCode = 1;
+  process.exit();
+}
+
+const isDryRun = process.argv.includes("--dry-run");
+
+if (isDryRun) {
+  ui.log("ℹ️  DRY RUN — no data will be deleted.");
+  ui.log();
+}
+
+// ---------------------------------------------------------------------------
+// Build the cleanup (or dry-run preview) script.
+// ---------------------------------------------------------------------------
+
+const countScript = `
+  echo "--- Webform submission count ---"
+  drush --uri="$WEBCMS_SITE_URL" sql:query "SELECT COUNT(*) AS submissions FROM webform_submission"
+  echo "--- Webform submission data count ---"
+  drush --uri="$WEBCMS_SITE_URL" sql:query "SELECT COUNT(*) AS submission_data FROM webform_submission_data"
+  echo "--- Webform config count ---"
+  drush --uri="$WEBCMS_SITE_URL" sql:query "SELECT COUNT(*) AS webform_configs FROM config WHERE name LIKE 'webform.webform.%'"
+`;
+
+const deleteScript = `
   echo "Deleting all webform submissions and webforms..."
   drush --uri="$WEBCMS_SITE_URL" sql:query "DELETE FROM webform_submission"
   drush --uri="$WEBCMS_SITE_URL" sql:query "DELETE FROM webform_submission_data"
@@ -15,8 +57,26 @@ const cleanupScript = `
   echo "Cleanup complete!"
 `;
 
+const cleanupScript = isDryRun ? countScript : countScript + deleteScript;
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
 async function main() {
-  ui.logHeading("ecs", "Running webform cleanup on dev environment");
+  const heading = isDryRun
+    ? "Previewing webform data on dev environment (DRY RUN)"
+    : "Running webform cleanup on dev environment";
+
+  ui.logHeading("ecs", heading);
+
+  if (!isDryRun) {
+    ui.log(
+      "⚠️  WARNING: This will permanently delete ALL webform submissions and webform config."
+    );
+    ui.log(`   Target: WEBCMS_SITE=${vars.site}  WEBCMS_ENVIRONMENT=${vars.environment}`);
+    ui.log();
+  }
 
   const task = await ecs.startDrushTask(cleanupScript);
   const taskUrl = await util.getTaskUrl(task);
@@ -41,22 +101,22 @@ async function main() {
 
     if (status !== lastSeenStatus) {
       lastSeenStatus = status;
-      ui.log(`Cleanup status: ${lastSeenStatus}`);
+      ui.log(`${isDryRun ? "Preview" : "Cleanup"} status: ${lastSeenStatus}`);
     }
 
     iterationCount++;
   }
 
   if (iterationCount >= maxIterations) {
-    throw new Error(`Cleanup task did not complete within ${maxIterations * 5 / 60} minutes`);
+    throw new Error(`Task did not complete within ${(maxIterations * 5) / 60} minutes`);
   }
 
   const info = util.inspectDrushStatus(finalStatus);
 
   ui.log(`Task stop: ${info.stop}`);
-  ui.log(`Cleanup exit: ${info.exit}`);
+  ui.log(`Exit: ${info.exit}`);
   if (info.signal) {
-    ui.log(`  NOTE: Cleanup exited from signal ${info.signal}`);
+    ui.log(`  NOTE: Task exited from signal ${info.signal}`);
   }
 
   ui.log();
@@ -65,12 +125,17 @@ async function main() {
   ui.log(ui.link(logsUrl, `Task logs`));
 
   if (!info.success) {
-    throw new Error("Cleanup task did not exit cleanly");
+    throw new Error("Task did not exit cleanly");
   }
 
   ui.log();
-  ui.log("✅ Webforms and submissions successfully deleted!");
-  ui.log("You can now run the deployment pipeline.");
+  if (isDryRun) {
+    ui.log("✅ Dry run complete — see row counts above.");
+    ui.log("   Re-run without --dry-run to perform the actual deletion.");
+  } else {
+    ui.log("✅ Webforms and submissions successfully deleted!");
+    ui.log("   You can now run the deployment pipeline.");
+  }
 }
 
 main()


### PR DESCRIPTION
The script deletes all webform submissions and webform config from the database with no guard against accidentally running on a non-dev environment — nothing prevented it from targeting stage or production.\n\nAdd an explicit check that `WEBCMS_SITE` is `dev` before proceeding. Add a `--dry-run` flag that prints row counts and the SQL that would run without executing anything. Print record counts before deletion so operators know the scope of what is about to be removed.