### PR TITLE
fix(ci): restore security scan branch filter rules in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,9 +109,15 @@ include:
 # Override stage assignment on parent config jobs (stage override is safe; rules override is not)
 sast:
   stage: Test
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "staging"'
+    - when: never
 
 dependency_scanning:
   stage: Test
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "staging"'
+    - when: never
 
 secret_detection:
   stage: Test


### PR DESCRIPTION
The rules limiting SAST, dependency scanning, and secret detection to the staging branch were commented out. GitLab defaults then applied the inherited template rules, running all three scans on every branch push and adding significant pipeline time to development branch builds.\n\nRestore rules on the analyzer sub-jobs (`semgrep-sast`, `gemnasium-dependency_scanning`, `secret_detection`) to restrict scanning to the staging branch. Add comments explaining why rules must not be overridden on the parent config-only jobs — doing so removes their built-in `when: never` rule and causes GitLab to attempt to execute them as real jobs.