### PR TITLE
fix(nginx): run envsubst on fastcgi-drupal.conf at container startup

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -203,10 +203,12 @@ COPY --from=drupal /var/www/html /var/www/html
 # Copy nginx configuration
 COPY status.conf *.map /etc/nginx/conf.d/
 
-# Copy configuration templates and the shared FastCGI parameter snippet.
-# fastcgi-drupal.conf is referenced via `include fastcgi-drupal.conf` from
-# default.conf.template, so it must land in nginx's default search path.
-COPY fastcgi-drupal.conf /etc/nginx/
+# Copy configuration templates.
+# fastcgi-drupal.conf contains $WEBCMS_DOMAIN which must be substituted at
+# container startup. Copy it into the templates directory so the nginx Docker
+# entrypoint (docker-entrypoint.sh) runs envsubst on it, producing
+# /etc/nginx/conf.d/fastcgi-drupal.conf alongside the processed default.conf.
+COPY fastcgi-drupal.conf /etc/nginx/templates/fastcgi-drupal.conf.template
 COPY default.conf /etc/nginx/templates/default.conf.template
 
 # Copy nginx startup script

--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -72,31 +72,31 @@ server {
   location = /newsreleases/search/rss {
     fastcgi_param PATH_INFO /newsreleases/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi-drupal.conf;
+    include conf.d/fastcgi-drupal.conf;
   }
 
   location = /faqs/search/rss {
     fastcgi_param PATH_INFO /faqs/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi-drupal.conf;
+    include conf.d/fastcgi-drupal.conf;
   }
 
   location = /publicnotices/notices-search/rss {
     fastcgi_param PATH_INFO /publicnotices/notices-search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi-drupal.conf;
+    include conf.d/fastcgi-drupal.conf;
   }
 
   location = /perspectives/search/rss {
     fastcgi_param PATH_INFO /perspectives/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi-drupal.conf;
+    include conf.d/fastcgi-drupal.conf;
   }
 
   location = /speeches/search/rss {
     fastcgi_param PATH_INFO /speeches/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
-    include fastcgi-drupal.conf;
+    include conf.d/fastcgi-drupal.conf;
   }
 
   # ---------------------------------------------------------------------------
@@ -140,7 +140,7 @@ server {
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    include fastcgi-drupal.conf;
+    include conf.d/fastcgi-drupal.conf;
   }
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`fastcgi-drupal.conf` references `$WEBCMS_DOMAIN`, which the nginx Docker
entrypoint must substitute before nginx starts. The file was being copied to
`/etc/nginx/` as a plain static file — the entrypoint only runs `envsubst`
on files in `/etc/nginx/templates/*.template`, so the substitution never
happened. nginx passed an empty `HTTP_HOST` header to Drupal on every request,
breaking the development environment after #1866 was merged.

## Fix

- Copy `fastcgi-drupal.conf` into `/etc/nginx/templates/` as
  `fastcgi-drupal.conf.template` so the entrypoint processes it alongside
  `default.conf.template`, producing the correctly-substituted
  `/etc/nginx/conf.d/fastcgi-drupal.conf` at container startup.
- Update all six `include fastcgi-drupal.conf` directives in `default.conf`
  to `include conf.d/fastcgi-drupal.conf` to match the new output path.

## Testing

- nginx starts cleanly with no missing include errors
- Drupal receives the correct `HTTP_HOST` header on all requests
- `$WEBCMS_DOMAIN` is fully substituted in the running container

## Notes

**This fix must also be applied to the `refactor/nginx-fastcgi-include` branch
(PR #1866) before it is merged to staging, otherwise the same breakage will
occur there.**