### PR TITLE
fastcgi_pass directive fix.

### DIFF
--- a/services/drupal/default.conf
+++ b/services/drupal/default.conf
@@ -63,40 +63,44 @@ server {
   # ---------------------------------------------------------------------------
   # RSS feed endpoints — bypass the 410 rules below and pass straight to PHP.
   #
-  # Each block only overrides the two parameters that differ from the shared
-  # fastcgi-drupal.conf include (PATH_INFO and SCRIPT_FILENAME). All other
-  # FastCGI parameters, buffer settings, and the upstream address are defined
-  # once in fastcgi-drupal.conf.
+  # Each block overrides PATH_INFO and SCRIPT_FILENAME and specifies the
+  # fastcgi_pass upstream. All other FastCGI parameters and buffer settings
+  # are defined once in fastcgi-drupal.conf.
   # ---------------------------------------------------------------------------
 
   location = /newsreleases/search/rss {
     fastcgi_param PATH_INFO /newsreleases/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
     include conf.d/fastcgi-drupal.conf;
+    fastcgi_pass localhost:9000;
   }
 
   location = /faqs/search/rss {
     fastcgi_param PATH_INFO /faqs/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
     include conf.d/fastcgi-drupal.conf;
+    fastcgi_pass localhost:9000;
   }
 
   location = /publicnotices/notices-search/rss {
     fastcgi_param PATH_INFO /publicnotices/notices-search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
     include conf.d/fastcgi-drupal.conf;
+    fastcgi_pass localhost:9000;
   }
 
   location = /perspectives/search/rss {
     fastcgi_param PATH_INFO /perspectives/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
     include conf.d/fastcgi-drupal.conf;
+    fastcgi_pass localhost:9000;
   }
 
   location = /speeches/search/rss {
     fastcgi_param PATH_INFO /speeches/search/rss;
     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
     include conf.d/fastcgi-drupal.conf;
+    fastcgi_pass localhost:9000;
   }
 
   # ---------------------------------------------------------------------------
@@ -141,6 +145,7 @@ server {
     fastcgi_param PATH_INFO $fastcgi_path_info;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     include conf.d/fastcgi-drupal.conf;
+    fastcgi_pass localhost:9000;
   }
 
   # ---------------------------------------------------------------------------

--- a/services/drupal/fastcgi-drupal.conf
+++ b/services/drupal/fastcgi-drupal.conf
@@ -1,13 +1,14 @@
 # Shared FastCGI parameters for all PHP locations.
 #
 # Include this file from any location block that passes requests to PHP-FPM, then
-# add only the parameters that differ per location (typically PATH_INFO and
-# SCRIPT_FILENAME). For example:
+# add only the parameters that differ per location (typically PATH_INFO,
+# SCRIPT_FILENAME, and fastcgi_pass). For example:
 #
 #   location = /some/path {
 #     fastcgi_param PATH_INFO /some/path;
 #     fastcgi_param SCRIPT_FILENAME $document_root/index.php;
 #     include fastcgi-drupal.conf;
+#     fastcgi_pass localhost:9000;
 #   }
 #
 # Note: nginx processes all `fastcgi_param` directives in a location block before
@@ -36,7 +37,7 @@ fastcgi_param REMOTE_ADDR $realip_remote_addr;
 # Suppress the PHP version disclosure header.
 fastcgi_hide_header X-Powered-By;
 
-# Buffer tuning — keep in sync with the main PHP location block below.
+# Buffer tuning for FastCGI responses.
 fastcgi_buffers 16 16k;
 fastcgi_buffer_size 32k;
 
@@ -44,6 +45,3 @@ fastcgi_buffer_size 32k;
 # forwarding PHP's raw error output to the client.
 fastcgi_intercept_errors on;
 
-# nginx and PHP-FPM are co-located in the same ECS task and share a network
-# namespace, so they communicate over localhost.
-fastcgi_pass localhost:9000;


### PR DESCRIPTION
Fix nginx startup failure caused by fastcgi_pass in shared include

After deploying to the development environment, the site returned 503 errors. nginx failed to start with:
The fastcgi_pass directive was placed in the shared fastcgi-drupal.conf include file, which the nginx Docker entrypoint outputs to /etc/nginx/conf.d/. Since nginx auto-includes all conf.d/*.conf files at the http context level — where fastcgi_pass is not valid — nginx could not start.

Changes
•  Removed fastcgi_pass localhost:9000; from services/drupal/fastcgi-drupal.conf
•  Added fastcgi_pass localhost:9000; to each location block in services/drupal/default.conf that includes the shared config (RSS feed endpoints and the main \.php$ block)
•  Updated comments in both files to reflect the correct usage pattern