### PR TITLE
docs: enrich contributing guide and codify development workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# CODEOWNERS — EPA WebCMS
+#
+# Code owners are automatically requested for review when a pull request changes
+# matching files. See:
+# https://docs.github.com/en/repositories/managing-your-repositories-growth/customizing-your-repository/about-code-owners
+#
+# The last matching pattern takes precedence. Patterns follow .gitignore syntax.
+#
+# NOTE: Owners must be real GitHub users (or teams) with write access to this
+# repository. The accounts below are repository maintainers. To route reviews to
+# a team instead of individuals, create a GitHub team (for example,
+# @USEPA/webcms-maintainers) and replace the individual handles below.
+
+# Default owners for everything in the repository.
+*                               @cherrypj @jmcerda-epa
+
+# Documentation and contributor-facing guidance.
+/CONTRIBUTING.md                @cherrypj @jmcerda-epa
+/README.md                      @cherrypj @jmcerda-epa
+/SECURITY.md                    @cherrypj @jmcerda-epa
+/CHANGELOG.md                   @cherrypj @jmcerda-epa
+/docs/                          @cherrypj @jmcerda-epa
+
+# CI/CD pipeline and deployment automation — changes here affect every
+# environment and require maintainer review.
+/.gitlab-ci.yml                 @cherrypj @jmcerda-epa
+/.gitlab/                       @cherrypj @jmcerda-epa
+/ci/                            @cherrypj @jmcerda-epa
+/push-dev.sh                    @cherrypj @jmcerda-epa
+/trigger-pipeline.sh            @cherrypj @jmcerda-epa
+/.github/                       @cherrypj @jmcerda-epa
+
+# Infrastructure as code — production-affecting; maintainer review required.
+/terraform/                     @cherrypj @jmcerda-epa
+
+# Drupal configuration — config and code must move together; review carefully.
+/services/drupal/config/        @cherrypj @jmcerda-epa

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# Issue tracking for the EPA WebCMS lives in Jira (project key WEBCMS) at
+# jira.epa.gov, not GitHub. Blank GitHub issues are disabled; the links below
+# route reporters to the correct system of record.
+blank_issues_enabled: false
+contact_links:
+  - name: Bug or feature request (Jira — WEBCMS)
+    url: https://jira.epa.gov/browse/WEBCMS
+    about: Tracked work for the WebCMS lives in Jira. Create or find the WEBCMS issue here; branches, commits, and PRs reference its key.
+  - name: Security vulnerability
+    url: https://www.epa.gov/vulnerability-disclosure-policy
+    about: Do not open a public issue for security problems. Report vulnerabilities privately — see SECURITY.md.
+  - name: WebCMS team (Slack)
+    url: https://epa.enterprise.slack.com
+    about: For questions and discussion, use the #webcms-dev channel.
+  - name: Deployment pipeline issues (GitLab)
+    url: https://gitlab.epa.gov/drupalcloud/drupalclouddeployment/-/issues
+    about: For CI/CD pipeline and deployment infrastructure issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,42 @@
-Closes {LINK TO JIRA ISSUE}
+Closes [WEBCMS-XXXX](https://jira.epa.gov/browse/WEBCMS-XXXX)
+
+<!-- Every PR references its Jira issue (project key WEBCMS) — Jira is the
+     system of record for tracked work. Replace WEBCMS-XXXX above with the real
+     issue key so it links automatically. -->
+
 
 ## Description
 
 A clear and concise description of the PR.
 
-Use this section for review hints, explanations or discussion points/todos.
+Use this section for review hints, explanations, or discussion points/todos.
 
 - Summary of changes
-- Reasoning
+- Reasoning / higher-level goal
 - Additional context
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Configuration change (content types, fields, permissions, workflow)
+- [ ] Theme / front-end change
+- [ ] CI/CD, infrastructure, or deployment change
+- [ ] Documentation update
+- [ ] Breaking change (fix or feature that would change existing behavior)
+
+## Target Branch
+
+- [ ] `development` (feature/bugfix work)
+- [ ] `main` (hotfix only — see [Git Workflow](../docs/GIT_WORKFLOW.md#hotfix-flow))
+
+## Testing & Evidence
+
+Describe how you validated this change. A reviewer should be able to see that the
+work was tested before it reached them.
+
+- How it was manually tested:
+- Commands run (e.g. `ddev drush deploy -y`, `ddev drush config:status`):
 
 ## Screenshots
 
@@ -16,16 +44,27 @@ Screenshots or a screen recording of the visual changes associated with this PR.
 
 (Feel free to delete this section for non-visual changes.)
 
+## Configuration & Deployment
+
+- [ ] Configuration was exported (`ddev drush cex`) and committed with the code
+- [ ] Module add/remove followed the [Config Sync Workflow](../services/drupal/CONFIG_SYNC_WORKFLOW.md)
+- [ ] This change requires a full build (Composer/theme/Docker/CI changes) — if so, note it here
+- [ ] No secrets, credentials, or `.env` files are committed
+
 ## Docs
 
-Add any notes that help to document the feature/changes: just a few words and/or code snippets.
+Add any notes that help to document the feature/changes: just a few words and/or
+code snippets.
 
 ## Ready?
 
-Did you do any of the following? If not, no worries, but if you can it's really helpful.
+Did you do any of the following? If not, no worries, but if you can it's really
+helpful.
 
 - [ ] Documented what's new
 - [ ] Added in-code documentation (wherever needed)
 - [ ] Wrote tests for new components/features
-- [ ] Ran the linter to ensure style guidelines were followed
+- [ ] Ran the linter (`ddev composer phpcs`, `ddev gesso lint`) to ensure style guidelines were followed
+- [ ] Ran static analysis (`ddev composer phpstan`)
 - [ ] Created a demo
+- [ ] Read and validated this description and the diff myself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to the EPA WebCMS are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Releases are tagged on `staging` using the date-based scheme `vYYYY.MM.DD` (with
+an optional `.N` sequence for multiple same-day releases), as described in the
+[Release Tagging Process](docs/GIT_WORKFLOW.md#release-tagging-process).
+
+Entry categories: **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**,
+**Security**.
+
+## [Unreleased]
+
+### Added
+
+- `docs/GIT_WORKFLOW.md`: dedicated, authoritative branching, merging, promotion,
+  hotfix, freeze, release-tagging, automated back-merge, branch-protection, and
+  roles & responsibilities reference.
+- `docs/cicd-pipeline.md`: CI/CD pipeline overview covering architecture,
+  branch-to-environment mapping, stages, build-once-deploy-many, skip-build,
+  security scanning, pipeline variables, notifications, and a reference map.
+- `SECURITY.md`: vulnerability reporting policy and scope.
+- `.github/CODEOWNERS`: review routing for documentation, CI/CD, infrastructure,
+  and Drupal configuration.
+- `.github/ISSUE_TEMPLATE/config.yml`: disables blank GitHub issues and redirects
+  reporters to the Jira `WEBCMS` project (the system of record), plus Slack,
+  security, and GitLab pipeline links.
+- `CHANGELOG.md`: this changelog.
+- `LICENSE.md`: root-level MIT License, matching the EPA standard used across
+  EPA repositories.
+
+### Changed
+
+- `CONTRIBUTING.md`: condensed the inline Git Workflow into a quick-reference
+  summary that links to `docs/GIT_WORKFLOW.md`, expanded Additional Resources
+  into a complete documentation index, and corrected the documentation and
+  license references.
+- `README.md`: corrected the documentation index and linked the Git Workflow and
+  CI/CD pipeline docs.
+- `.github/pull_request_template.md`: expanded into a structured template with
+  change type, testing evidence, configuration/deployment, and a reviewer
+  checklist.
+
+### Fixed
+
+- Removed broken documentation links (a non-existent `WARP.md` reference in
+  `README.md`, and `docs/` references in `CONTRIBUTING.md` that pointed at files
+  that did not exist).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@ Thank you for contributing to the EPA WebCMS project! This guide will help you s
 Note that a good pull request has the following characteristics:
 
 - The code works, and you are confident that it works. Your job is to deliver code that works.
-- The change is small enough to be reviewed efficiently without inflicting too much additional cognitive load on the reviewer. Several small PRs beats one big one, and splitting code into separate commits is easy with a coding agent to do the Git finagling for you.
-- The PR includes additional context to help explain the change. What's the higher level goal that the change serves? Linking to relevant issues or specifications is useful here.
-- Agents write convincing looking pull request descriptions. You need to review these too! It's rude to expect someone else to read text that you haven't read and validated yourself.
+- The change is small enough to be reviewed efficiently without inflicting too much additional cognitive load on the reviewer. Several small PRs beat one big one, and splitting work into separate, focused commits is straightforward with `git add -p` and an interactive rebase.
+- The PR includes additional context to help explain the change. What's the higher-level goal that the change serves? Linking to relevant issues or specifications is useful here.
+- A convincing-looking pull request description still has to be accurate. Read and validate your own description before you ask anyone else to read it — it's rude to expect a reviewer to work through text you haven't checked yourself.
 
-Given how easy it is to dump unreviewed code on other people, please include some form of evidence that you've put that extra work in yourself. Notes on how you manually tested it, comments on specific implementation choices or even screenshots and video of the feature working go a long way to demonstrating that a reviewer's time will not be wasted digging into the details.
+Given how easy it is to hand unreviewed code to a reviewer, please include some form of evidence that you've put that extra work in yourself. Notes on how you manually tested it, comments on specific implementation choices, or even screenshots and video of the feature working go a long way toward demonstrating that a reviewer's time will not be wasted digging into the details.
 
 ## Table of Contents
 
@@ -588,20 +588,29 @@ See [README.md Advanced Pipeline Variables](README.md#advanced-pipeline-variable
 
 ## Git Workflow
 
-Our process adapts GitHub Flow to EPA WebCMS’ multi-environment deployment model.
+Our process adapts **GitHub Flow** to the EPA WebCMS multi-environment
+deployment model: **feature → development → staging → main**. Code is hosted on
+GitHub and deployed through a GitLab mirror into AWS ECS.
+
+> **The full branching, merging, and release reference lives in
+> [docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md).** It is the single source of
+> truth for branch protection, the promotion and hotfix flows, the freeze
+> protocol, release tagging, the automated back-merge, and roles &
+> responsibilities. The summary below is the quick reference for day-to-day work.
 
 ### Goals
 
 1. Keep `main` always releasable and aligned with production.
-2. Ensure every change is validated in the dev environment (`development` branch) before moving to stage/production.
-3. Provide a lightweight, repeatable promotion path: **feature → development → staging → main**.
+2. Validate every change in the dev environment (`development`) before it moves
+   to stage or production.
+3. Provide a lightweight, repeatable promotion path.
 4. Support urgent hotfixes without blocking regular feature work.
 
 ### Branch Roles
 
 | Branch | Purpose | Deployment Target | Notes |
 |--------|---------|-------------------|-------|
-| `main` | Production source of truth | Production (manual pipeline trigger) | Locked; release merges and hotfixes only. See [Branch Protection](#branch-protection-configuration). |
+| `main` | Production source of truth | Production (manual pipeline trigger) | Locked; release merges and hotfixes only. |
 | `staging` | Stage/staging code | Stage environment | Mirrors upcoming production; runs full security scans. |
 | `development` | Active integration branch | Dev environment | All feature work branches from here. Triggers the standard dev pipeline (`push-dev.sh`). |
 | `feature/*`, `bugfix/*` | Short-lived work branches | None directly | Always branch from `development` and open PRs back into `development`. |
@@ -609,261 +618,51 @@ Our process adapts GitHub Flow to EPA WebCMS’ multi-environment deployment mod
 
 ### Standard Feature Flow
 
-1. **Sync development**
-   ```bash
-   git checkout development
-   git pull origin development
-   ```
-2. **Branch from `development`**
-   ```bash
-   git checkout -b feature/<short-description>
-   ```
-   Include ticket number in branch name if applicable.
-3. **Develop & validate locally**
-   - Use DDEV & Gesso commands in this guide.
-   - Follow Conventional Commits and keep commits focused.
-   - Periodically sync with latest changes: `git fetch origin && git rebase origin/development`
-4. **PR into `development`**
-   - Target branch: `development`.
-   - Run local checks; after merge trigger `./push-dev.sh --skip-build` for fast validation.
-   - Resolve review feedback and merge (squash or rebase preferred).
-5. **Promote to Stage (`staging`)**
-   - On release cadence, merge `development` → `staging`.
-   - Push to `staging` to run full stage pipeline (security scans included).
-   - **EPA staff only**
-6. **Promote to Production (`main`)**
-   - After stage sign-off, follow the [Stage-to-Production Promotion Checklist](#stage-to-production-promotion-checklist).
-   - Michael Hessling tags the release on `staging` (see [Release Tagging Process](#release-tagging-process)).
-   - Merge `staging` → `main` via PR (merge commit), then trigger the production pipeline.
-   - The production pipeline **does not rebuild images** — it promotes the same images tested on stage (build once, deploy many).
-   - **EPA staff only**
-7. **Back-merge to development**
-   - After production release, merge `main` → `development` using a **merge commit** (not rebase).
-   - An automated CI job opens this PR; see [Automated Back-Merge](#automated-back-merge).
-   - If the auto-PR has conflicts, resolve manually:
-   ```bash
-   git checkout development
-   git pull origin development
-   git merge origin/main
-   # Resolve conflicts, then push
-   git push origin development
-   ```
+1. **Sync `development`** — `git checkout development && git pull origin development`
+2. **Branch from `development`** — `git checkout -b feature/<short-description>`
+   (include the ticket number if applicable).
+3. **Develop & validate locally** — follow [Conventional Commits](#commit-message-convention),
+   keep commits focused, and periodically `git fetch origin && git rebase origin/development`.
+   Run the local quality gates before opening a PR: `ddev drush updb -y`,
+   `ddev drush cex`, `ddev composer phpcs`, `ddev composer phpstan`, and
+   `ddev gesso build` if you touched theme source.
+4. **Open a PR into `development`** — fill out the
+   [pull request template](.github/pull_request_template.md), then trigger
+   `./push-dev.sh --skip-build` for fast validation after merge.
+5. **Promote to Stage (`staging`)** — *EPA staff only*; merge `development` →
+   `staging` on the release cadence and let the full stage pipeline run.
+6. **Promote to Production (`main`)** — *EPA staff only*; follow the
+   [Stage-to-Production Promotion Checklist](docs/GIT_WORKFLOW.md#stage-to-production-promotion-checklist).
+   Production promotes the same images tested on stage — no rebuild.
+7. **Back-merge to `development`** — merge `main` → `development` with a merge
+   commit after each release (an automated CI job opens this PR).
 
-### Hotfix Flow
-
-Hotfixes bypass the normal `development → staging → main` promotion path to get urgent fixes into production quickly. **EPA staff only** for merge and deploy steps.
-
-1. **Branch from `main`**
-   ```bash
-   git checkout main
-   git pull origin main
-   git checkout -b hotfix/<issue-description>
-   ```
-2. **Implement and validate locally**
-   - Fix the issue and test with `ddev drush deploy -y` and `ddev drush config:status`.
-   - Follow the same code quality checks as any other PR.
-3. **Open PR targeting `main`**
-   - Requires at least one maintainer approval.
-   - PR description should explain the urgency and what is broken in production.
-4. **Merge into `main`** (merge commit, do not squash)
-5. **Tag and deploy to production**
-   - Michael Hessling tags the hotfix on `main` (see [Release Tagging Process](#release-tagging-process)).
-   - Sync GitLab mirror (manual sync — do not wait for auto-sync).
-   - Trigger the production pipeline manually on GitLab (`main` branch).
-   - Monitor pipeline to completion and verify the production site.
-6. **Sync the fix to `staging` and `development`**
-   - Cherry-pick or merge the hotfix into `staging`:
-     ```bash
-     git checkout staging
-     git pull origin staging
-     git cherry-pick <hotfix-merge-commit-sha>
-     git push origin staging
-     ```
-   - The automated back-merge CI job will open a PR from `main` → `development`. If it doesn't cover the fix (e.g., due to conflicts), cherry-pick into `development` manually.
-   - **All three branches (`main`, `staging`, `development`) must contain the hotfix before the next sprint cycle.**
-7. **Communicate** — announce the hotfix and its deployment in #webcms-dev.
-
-### Why Branch From `development`?
-
-- **Industry standard (Git Flow):** Features integrate continuously in the active development branch.
-- **Early conflict detection:** Features see each other immediately, catching integration issues during development rather than at PR time.
-- **Simplified workflow:** Eliminates need for developers to manually rebase against `development` as it diverges from `main`.
-- **Natural integration:** Multiple features can be tested together in the dev environment before promotion.
-- **Aligned with deployment model:** The branch you develop in is the branch that deploys to dev.
-
-### Release Cadence & Coordination
-
-- **Daily Dev Deploys:** Merge PRs into `development` as they're approved. Use skip-build for quick iterations; run one full build per day or after dependency changes.
-- **Stage Deploys:** At least once per sprint (or as needed). Merge `development` → `staging`, let the stage pipeline run, and perform QA.
-- **Production Deploys:** After stage QA sign-off, follow the [Stage-to-Production Promotion Checklist](#stage-to-production-promotion-checklist). Michael Hessling tags the release on `staging` and triggers the production pipeline on GitLab after merging to `main`.
-- **Back-merge:** After each production release, immediately merge `main` → `development` (merge commit). An automated CI job opens this PR; see [Automated Back-Merge](#automated-back-merge).
-
-### Pull Request Guidelines
-
-- Target branches: Feature work → `development`, hotfixes → `main`.
-- Write well-documented PRs, following the template generated when creating a new PR.
-- Keep PRs reviewable (< ~1 day of work). Use draft PRs for early feedback.
-- Run `ddev drush updb`, `ddev drush cex`, `ddev composer phpcs`, `phpstan`, theme builds, and relevant tests before creating PR and requesting review.
-- Require at least one maintainer approval.
-- Do NOT bundle multiple module updates into one PR, unless they're related (like metatag and metatag_schema).
+For the **hotfix flow**, the **freeze protocol**, **release tagging**, the
+**automated back-merge** job, and **branch protection settings**, see
+[docs/GIT_WORKFLOW.md](docs/GIT_WORKFLOW.md).
 
 ### Merge Strategy
 
-- **Feature PRs:** Squash or rebase onto `development` to maintain a clean history.
-- **Promotions (`development` → `staging`, `staging` → `main`):** Use merge commits so a release corresponds to a single identifiable merge.
-- **Back-merges (`main` → `development`):** Use a **merge commit**, not rebase or fast-forward. This preserves commit hashes on `development` so no one's local branch is invalidated. The merge commit also serves as an audit trail for when production state was synced back.
+- **Feature/bugfix PRs → `development`:** squash or rebase (clean history).
+- **Promotions (`development` → `staging`, `staging` → `main`):** merge commits,
+  so each release is one identifiable merge.
+- **Hotfix → `main`:** merge commit (never squash), so commits can be
+  cherry-picked to `staging`/`development`.
+- **Back-merges (`main` → `development`):** merge commit (not rebase/fast-forward),
+  to preserve commit hashes and provide an audit trail.
 
-### FAQs
+### Pull Request Guidelines
 
-- **Why not branch from `main` directly?** Branching from `main` causes feature branches to diverge from active development work. By the time a feature is ready, it's missing weeks of changes merged to `development`, leading to late-stage conflicts.
-- **Can I deploy from a feature branch?** No. Only `development` (dev) and `staging` (stage) trigger automatic deployments. Production deploys from `main` via manual pipeline trigger.
-- **What if a feature spans multiple sprints?** Periodically rebase on `development` to stay current with integrated work. Use feature flags for incomplete functionality.
-- **How do freeze periods work?** See [Freeze Protocol](#freeze-protocol) for the full process.
-
-### Release Tagging Process
-
-Michael Hessling creates the release tag on `staging` **before** merging to `main`. The tag marks the exact commit whose Docker images were built and tested on stage — this is the audit trail linking what was tested to what gets deployed.
-
-**Tag format:** `vYYYY.MM.DD` (e.g., `v2026.04.09`). For multiple same-day releases, append a sequence number: `v2026.04.09.2`.
-
-**Steps:**
-1. Confirm stage QA is complete and sign-off is received.
-2. Tag the release on `staging`:
-   ```bash
-   git checkout staging
-   git pull origin staging
-   git tag -a vYYYY.MM.DD -m "Release vYYYY.MM.DD: <brief summary>"
-   git push origin vYYYY.MM.DD
-   ```
-3. Merge `staging` → `main` via PR (merge commit).
-4. Sync GitLab mirror and trigger the production pipeline on GitLab (`main` branch). The production pipeline promotes the images built from the tagged staging commit — no rebuild.
-
-### Freeze Protocol
-
-A code freeze restricts merges to stabilize the codebase before a production release.
-
-**Initiating a Freeze:**
-1. Release manager (Michael Hessling) announces the freeze in #webcms-dev Slack with the expected duration and target release date.
-2. During the freeze, **no new PRs are merged into `development`** except:
-   - Critical bug fixes required for the release
-   - Documentation-only changes
-3. In-progress feature branches should be rebased on `development` but held until the freeze lifts.
-
-**During the Freeze:**
-1. QA and validation happen on the `staging` (stage) environment.
-2. Critical fixes follow the hotfix flow: branch from `main` or `staging`, fix, PR, merge.
-3. All hotfixes merged during the freeze must be communicated in #webcms-dev.
-
-**Lifting the Freeze:**
-1. Production release is deployed and verified.
-2. Back-merge `main` → `development` (merge commit) to incorporate freeze-period hotfixes.
-3. Release manager announces the freeze is lifted in #webcms-dev.
-4. Held PRs can resume merging into `development`.
-
-### Stage-to-Production Promotion Checklist
-
-Follow this checklist when promoting from stage to production. **All steps are EPA staff only.**
-
-**Pre-Promotion:**
-- [ ] Stage QA is complete
-- [ ] Stakeholder sign-off received
-- [ ] No outstanding critical bugs on stage
-- [ ] If a freeze is needed, initiate the [Freeze Protocol](#freeze-protocol)
-- [ ] Announce planned production deployment in #webcms-dev
-
-**Promotion:**
-- [ ] Michael Hessling tags the release on `staging` (see [Release Tagging Process](#release-tagging-process))
-- [ ] Create PR: `staging` → `main` on GitHub
-- [ ] Review PR — verify it contains only the expected changes
-- [ ] Merge PR using a merge commit (do not squash)
-- [ ] Sync GitLab mirror
-- [ ] Trigger production pipeline manually on GitLab (`main` branch)
-- [ ] Monitor pipeline to completion
-
-**Post-Promotion:**
-- [ ] Verify production site is healthy (smoke test key pages and workflows)
-- [ ] Confirm ECS service updated in AWS Console
-- [ ] Merge the automated back-merge PR (`main` → `development`); resolve conflicts if any
-- [ ] Announce deployment complete in #webcms-dev
-- [ ] If a freeze was in effect, lift it
-
-### Automated Back-Merge
-
-To prevent `development` from drifting behind `main`, a GitLab CI job automatically opens a GitHub PR from `main` → `development` after any push to `main`.
-
-**How it works:**
-1. When the GitLab mirror syncs a new commit on `main`, the `open-backmerge-pr` CI job runs.
-2. The job checks for an existing open back-merge PR to avoid duplicates.
-3. If none exists, it creates a PR from `main` → `development` via the GitHub API.
-4. The team reviews and merges the PR. If there are conflicts, a developer resolves them manually.
-
-**GitLab CI job** (implemented in `.gitlab-ci.yml`):
-
-```yaml
-open-backmerge-pr:
-  stage: .post
-  image: alpine:latest
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
-  before_script:
-    - apk add --no-cache curl jq
-  script:
-    - |
-      EXISTING=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-        "https://api.github.com/repos/USEPA/webcms/pulls?head=USEPA:main&base=development&state=open" \
-        | jq length)
-      if [ "$EXISTING" -gt 0 ]; then
-        echo "Back-merge PR already exists, skipping."
-        exit 0
-      fi
-      curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
-        -H "Content-Type: application/json" \
-        "https://api.github.com/repos/USEPA/webcms/pulls" \
-        -d '{
-          "title": "chore: back-merge main into development",
-          "body": "Automated back-merge to sync production state into development after release.",
-          "head": "main",
-          "base": "development"
-        }'
-  allow_failure: true
-```
-
-**Required setup:**
-- Add `GITHUB_TOKEN` as a protected, masked CI/CD variable in GitLab (Settings → CI/CD → Variables) with `repo` scope.
-
-### Branch Protection Configuration
-
-GitHub branch protection rules for this repository. Audit these periodically to ensure they remain in effect.
-
-**To configure:** GitHub → Repository Settings → Branches → Branch protection rules.
-
-#### `main` (production)
-- ✅ Require a pull request before merging
-  - Required approvals: **1** (maintainer)
-  - Dismiss stale pull request approvals when new commits are pushed
-- ✅ Require status checks to pass before merging
-- ✅ Require branches to be up to date before merging
-- ✅ Do not allow force pushes
-- ✅ Do not allow deletions
-- ✅ Restrict who can push: EPA staff / repository maintainers only
-
-#### `staging` (stage)
-- ✅ Require a pull request before merging
-  - Required approvals: **1** (maintainer)
-- ✅ Require status checks to pass before merging
-- ✅ Do not allow force pushes
-- ✅ Do not allow deletions
-- ✅ Restrict who can push: EPA staff / repository maintainers only
-
-#### `development` (dev)
-- ✅ Require a pull request before merging
-  - Required approvals: **1**
-- ✅ Do not allow force pushes
-
-#### Feature branches (`feature/*`, `bugfix/*`, `hotfix/*`)
-- No branch protection rules required
-- Developers manage their own branches
-- Delete branches after merge
+- Target branches: feature/bugfix work → `development`; hotfixes → `main`.
+- Keep PRs reviewable (roughly less than a day of work); use draft PRs for early
+  feedback.
+- Require at least one maintainer approval.
+- Do **not** bundle unrelated module updates into one PR, unless they're coupled
+  (like `metatag` and `metatag_schema`).
+- Configuration changes travel with code — never commit config in code and
+  database simultaneously, and follow the
+  [Config Sync Workflow](services/drupal/CONFIG_SYNC_WORKFLOW.md) when adding or
+  removing modules.
 
 ### Commit Message Convention
 
@@ -1197,25 +996,43 @@ ddev restart
 
 - **Slack:** #webcms-dev channel
 - **Email:** webcms-team@epa.gov
-- **GitLab Issues:** https://gitlab.epa.gov/drupalcloud/drupalclouddeployment/-/issues
-- **Documentation:** See `docs/` directory
+- **Issue tracking (Jira):** WebCMS work is tracked in Jira under the **`WEBCMS`** project — `https://jira.epa.gov/browse/WEBCMS`. This is the system of record for bugs and features; branches, commits, and PRs reference the WEBCMS key.
+- **Deployment pipeline issues (GitLab):** https://gitlab.epa.gov/drupalcloud/drupalclouddeployment/-/issues
+- **Documentation:** See the [`docs/`](docs/) directory and the [Additional Resources](#additional-resources) below
 
 ---
 
 ## Additional Resources
 
-- [CI/CD Pipeline Documentation](docs/cicd-pipeline.md)
+**Project documentation**
+
+- [Git Workflow](docs/GIT_WORKFLOW.md) — branching, merging, promotion, and release process
+- [CI/CD Pipeline](docs/cicd-pipeline.md) — pipeline architecture, stages, and variables
+- [Deployment Workflow](.gitlab/DEPLOYMENT_WORKFLOW.md) — step-by-step manual deployment
+- [Pipeline Optimizations](.gitlab/PIPELINE_OPTIMIZATIONS.md) — dev vs. stage performance tuning
+- [Security Scanning Troubleshooting](.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md) — GitLab security template gotchas
+- [Config Sync Workflow](services/drupal/CONFIG_SYNC_WORKFLOW.md) — safe module add/remove and config export
+- [Teams Notifications](.gitlab/TEAMS_NOTIFICATIONS.md) — pipeline notification setup
 - [Terraform Infrastructure](terraform/infrastructure/README.md)
 - [Terraform WebCMS Deployment](terraform/webcms/README.md)
 - [Docker Build Configuration](.gitlab/docker.yml)
+- [Security Policy](SECURITY.md) — reporting vulnerabilities
+
+**External documentation**
+
 - [Drupal Documentation](https://www.drupal.org/docs)
 - [DDEV Documentation](https://ddev.readthedocs.io/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
 
 ---
 
 ## License
 
-See [LICENSE](LICENSE) file for details.
+This project is released under the MIT License; see [`LICENSE.md`](LICENSE.md).
+The bundled Drupal application code carries its own GNU General Public License v2
+(or later); see [`services/drupal/LICENSE`](services/drupal/LICENSE). As a work
+of the United States Government, EPA-authored content is generally not subject to
+domestic copyright protection (see the [Disclaimer](#disclaimer) below).
 
 ## Disclaimer
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+# MIT License
+
+Copyright (c) 2019  U.S. Federal Government (in countries where recognized)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ Access the site at: <https://epa.ddev.site>
 ## Documentation
 
 - **[Contributing Guide](CONTRIBUTING.md)** - Complete setup instructions, development workflows, and deployment guide
-- **[WARP.md](WARP.md)** - AI agent guidance for working with this repository
-- **[Git Workflow](docs/GIT_WORKFLOW.md)** - Branching and release process
-- **[CI/CD Pipeline](.gitlab-ci.yml)** - GitLab CI configuration for automated deployments
+- **[Git Workflow](docs/GIT_WORKFLOW.md)** - Branching, merging, promotion, and release process
+- **[CI/CD Pipeline](docs/cicd-pipeline.md)** - Pipeline architecture, stages, and variables (configuration: [`.gitlab-ci.yml`](.gitlab-ci.yml))
 - **[Deployment Workflow](.gitlab/DEPLOYMENT_WORKFLOW.md)** - Step-by-step deployment process
 - **[Pipeline Optimizations](.gitlab/PIPELINE_OPTIMIZATIONS.md)** - Performance optimization details
 - **[Security Scanning Troubleshooting](.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md)** - Root cause, debugging steps, and mitigation for GitLab security template override failures
 - **[Drupal Config Sync Workflow](services/drupal/CONFIG_SYNC_WORKFLOW.md)** - Proper module uninstall, config export, Composer update, and deployment-safe workflow
+- **[Security Policy](SECURITY.md)** - How to report a vulnerability
+- **[License](LICENSE.md)** - MIT License
 - **[Terraform Infrastructure](terraform/infrastructure/README.md)** - AWS infrastructure provisioning
 - **[Terraform WebCMS](terraform/webcms/README.md)** - Application deployment configuration
 
@@ -289,6 +290,9 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `staging` - Pre-production (deploys to stage)
 - `development` - Active development (deploys to dev)
 - `feature/*`, `bugfix/*`, `hotfix/*` - Feature branches
+
+See the [Git Workflow](docs/GIT_WORKFLOW.md) for the full branching, merging,
+promotion, hotfix, freeze, and release-tagging process.
 
 ## Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+The EPA WebCMS is the public-facing content management system for EPA.gov. We
+take the security of this codebase and the data it handles seriously. This
+document explains how to report a vulnerability and what to expect in response.
+
+## Reporting a Vulnerability
+
+**Do not report security vulnerabilities through public GitHub issues, pull
+requests, or the #webcms-dev Slack channel.** Public disclosure before a fix is
+available puts the platform and its users at risk.
+
+Instead, report suspected vulnerabilities privately through one of the following:
+
+- **EPA vulnerability disclosure:** Follow the U.S. EPA Vulnerability Disclosure
+  Policy at <https://www.epa.gov/vulnerability-disclosure-policy>. This is the
+  preferred channel for anyone outside the WebCMS team.
+- **WebCMS team (internal reporters):** Email the WebCMS team at
+  `webcms-team@epa.gov` with the subject line prefixed `[SECURITY]`. Do not
+  include exploit details in Slack.
+
+When reporting, please include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact.
+- The affected component, URL, or file path.
+- Step-by-step instructions to reproduce the issue.
+- Any proof-of-concept code, request/response captures, or screenshots.
+- Suggested remediation, if you have one.
+
+Please **do not** include live secrets, production credentials, or real user
+personal data in your report. Redact sensitive values and describe them instead.
+
+## What to Expect
+
+- **Acknowledgement:** We aim to acknowledge a report within a few business days.
+- **Assessment:** We triage by severity and confirm whether the issue is
+  reproducible.
+- **Remediation:** Confirmed issues are tracked privately, fixed, and deployed
+  following the [Git Workflow](docs/GIT_WORKFLOW.md) — typically via the
+  [hotfix flow](docs/GIT_WORKFLOW.md#hotfix-flow) when the severity warrants it.
+- **Coordinated disclosure:** We will coordinate timing of any public disclosure
+  with the reporter where appropriate.
+
+## Scope
+
+This policy covers the source code in this repository (`USEPA/webcms`): the
+Drupal application in `services/drupal/`, custom modules and themes, the CI/CD
+pipeline configuration, and the Terraform infrastructure code.
+
+For production-site issues that are not specific to this source code (for
+example, content problems or live-site availability), use the EPA channels at
+<https://www.epa.gov> rather than this repository.
+
+## Supported Versions
+
+This repository follows a rolling-release model — the `main` branch reflects what
+is currently in production. Security fixes are applied to `main` (and back-merged
+to `staging` and `development`); there are no separately maintained older release
+branches.
+
+## Dependency and Code Security
+
+The pipeline and tooling include several automated safeguards:
+
+- **Dependency updates** via Dependabot (see [`.github/dependabot.yml`](.github/dependabot.yml)).
+- **SAST, dependency scanning, and secret detection** on the `staging` branch
+  (see [CI/CD Pipeline → Security Scanning](docs/cicd-pipeline.md#security-scanning)).
+- **Container image scanning** (Prisma Cloud) for stage-bound images.
+
+Contributors are expected to follow the security guidance in
+[CONTRIBUTING.md](CONTRIBUTING.md#security-best-practices): never commit secrets
+or credentials, use environment variables for sensitive data, sanitize user
+input, and follow
+[Drupal security best practices](https://www.drupal.org/docs/security-in-drupal).

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -1,0 +1,525 @@
+# Git Workflow
+
+This is the authoritative branching, merging, and release reference for the EPA
+WebCMS. It applies to everyone who contributes code — EPA staff, contractors,
+and middleware engineers alike. [CONTRIBUTING.md](../CONTRIBUTING.md) links here
+for the full workflow; this document is the single source of truth for how
+changes move from a developer's machine to production.
+
+Our process adapts **GitHub Flow** to the EPA WebCMS multi-environment
+deployment model. Code lives on GitHub (`USEPA/webcms`); deployment runs through
+a GitLab mirror into AWS ECS. See [docs/cicd-pipeline.md](cicd-pipeline.md) for
+how each branch maps onto the pipeline.
+
+## Table of Contents
+
+- [Goals](#goals)
+- [Branch Roles](#branch-roles)
+- [The Promotion Path at a Glance](#the-promotion-path-at-a-glance)
+- [Issue Tracking (Jira)](#issue-tracking-jira)
+- [Branch Naming](#branch-naming)
+- [Standard Feature Flow](#standard-feature-flow)
+- [Hotfix Flow](#hotfix-flow)
+- [Why Branch From `development`?](#why-branch-from-development)
+- [Merge Strategy](#merge-strategy)
+- [Commit Message Convention](#commit-message-convention)
+- [Pull Request Guidelines](#pull-request-guidelines)
+- [Release Cadence & Coordination](#release-cadence--coordination)
+- [Release Tagging Process](#release-tagging-process)
+- [Stage-to-Production Promotion Checklist](#stage-to-production-promotion-checklist)
+- [Freeze Protocol](#freeze-protocol)
+- [Automated Back-Merge](#automated-back-merge)
+- [Branch Protection Configuration](#branch-protection-configuration)
+- [Roles & Responsibilities](#roles--responsibilities)
+- [FAQs](#faqs)
+
+## Goals
+
+1. Keep `main` always releasable and aligned with production.
+2. Ensure every change is validated in the dev environment (`development`
+   branch) before moving to stage or production.
+3. Provide a lightweight, repeatable promotion path:
+   **feature → development → staging → main**.
+4. Support urgent hotfixes without blocking regular feature work.
+5. Preserve a clear audit trail: any commit in production can be traced back to
+   the review, the stage validation, and the release tag that shipped it.
+
+## Branch Roles
+
+| Branch | Purpose | Deployment Target | Notes |
+|--------|---------|-------------------|-------|
+| `main` | Production source of truth | Production (manual pipeline trigger) | Locked; release merges and hotfixes only. See [Branch Protection](#branch-protection-configuration). |
+| `staging` | Stage/staging code | Stage environment | Mirrors upcoming production; runs full security scans. |
+| `development` | Active integration branch | Dev environment | All feature work branches from here. Triggers the standard dev pipeline (`push-dev.sh`). |
+| `feature/*`, `bugfix/*` | Short-lived work branches | None directly | Always branch from `development` and open PRs back into `development`. |
+| `hotfix/*` | Urgent fixes for prod | Main & staging | Created from `main`, merged back to all branches after release. |
+
+`main`, `staging`, and `development` are **long-lived** branches that map
+one-to-one onto a deployed environment. Everything else is **short-lived** and
+should be deleted after merge.
+
+## The Promotion Path at a Glance
+
+```
+  feature/* ─┐
+  bugfix/*  ─┼─▶ development ──▶ staging ──▶ main
+             │   (dev env)      (stage env)  (production)
+  hotfix/* ──┘ (branches from main; back-merged to all)
+```
+
+- **Forward promotion** uses merge commits so each environment advance is a
+  single, identifiable merge.
+- **Back-merge** (`main → development`) keeps the integration branch from
+  drifting behind production. It is automated; see
+  [Automated Back-Merge](#automated-back-merge).
+
+## Issue Tracking (Jira)
+
+WebCMS work is tracked in **Jira**, not GitHub Issues. The Jira project is
+**`WEBCMS`** (for example, `WEBCMS-307`), served from
+`https://jira.epa.gov/browse/WEBCMS`. Jira is the **system of record**
+for bugs and features; the GitHub Issues tab is disabled and redirects there (see
+[`.github/ISSUE_TEMPLATE/config.yml`](../.github/ISSUE_TEMPLATE/config.yml)).
+
+So that every change is traceable back to the work that motivated it:
+
+- **Branch** — include the WEBCMS key in the name:
+  `feature/WEBCMS-412-alert-banner`.
+- **Commit** — start the subject with the key, or reference it in the footer:
+  `feat(alerts): WEBCMS-412 add site-wide alert banner`.
+- **Pull request** — link the Jira issue in the description (the
+  [PR template](../.github/pull_request_template.md) opens with
+  `Closes WEBCMS-XXXX`).
+
+A change without a Jira key has no traceable home — create or find the WEBCMS
+issue before you start. (Deployment-pipeline and CI/CD infrastructure issues are
+tracked separately in GitLab; see
+[CONTRIBUTING.md → Getting Help](../CONTRIBUTING.md#getting-help).)
+
+## Branch Naming
+
+Use a `type/` prefix and a short, hyphenated, lowercase description. Include the
+WEBCMS Jira key so the branch, commits, and PR all link back to the same work
+item.
+
+| Type | Use for | Branch from | PR target | Example |
+|------|---------|-------------|-----------|---------|
+| `feature/` | New functionality | `development` | `development` | `feature/WEBCMS-412-alert-banner` |
+| `bugfix/` | Non-urgent bug fixes | `development` | `development` | `bugfix/WEBCMS-418-menu-breakpoint` |
+| `hotfix/` | Urgent production fixes | `main` | `main` | `hotfix/WEBCMS-431-xss-patch` |
+
+Guidelines:
+
+- Keep slugs short but descriptive — the branch name should make the intent
+  obvious without opening the PR.
+- One logical change per branch. If you find yourself naming a branch
+  `feature/several-things`, split it.
+- Delete the branch after it merges (locally and on the remote).
+
+## Standard Feature Flow
+
+1. **Sync `development`**
+   ```bash
+   git checkout development
+   git pull origin development
+   ```
+2. **Branch from `development`**
+   ```bash
+   git checkout -b feature/<short-description>
+   ```
+   Include the ticket number in the branch name if applicable.
+3. **Develop & validate locally**
+   - Use the DDEV and Gesso commands documented in
+     [CONTRIBUTING.md](../CONTRIBUTING.md).
+   - Follow [Conventional Commits](#commit-message-convention) and keep commits
+     focused.
+   - Periodically sync with the latest integrated work:
+     ```bash
+     git fetch origin && git rebase origin/development
+     ```
+   - Run the local quality gates before opening a PR:
+     ```bash
+     ddev drush updb -y
+     ddev drush cex          # export config you changed
+     ddev composer phpcs
+     ddev composer phpstan
+     ddev gesso build        # if you touched theme source
+     ```
+4. **Open a PR into `development`**
+   - Target branch: `development`.
+   - Fill out the [pull request template](../.github/pull_request_template.md)
+     completely, including the tracking issue link and manual-test evidence.
+   - After merge, trigger `./push-dev.sh --skip-build` for fast validation in
+     the dev environment.
+   - Resolve review feedback. Merge with **squash or rebase** to keep
+     `development` history clean.
+5. **Promote to Stage (`staging`)** — *EPA staff only*
+   - On the release cadence, merge `development` → `staging`.
+   - Push to `staging` to run the full stage pipeline (security scans included).
+6. **Promote to Production (`main`)** — *EPA staff only*
+   - After stage sign-off, follow the
+     [Stage-to-Production Promotion Checklist](#stage-to-production-promotion-checklist).
+   - The release manager tags the release on `staging` (see
+     [Release Tagging Process](#release-tagging-process)).
+   - Merge `staging` → `main` via PR (merge commit), then trigger the production
+     pipeline.
+   - The production pipeline **does not rebuild images** — it promotes the same
+     images tested on stage (build once, deploy many).
+7. **Back-merge to `development`**
+   - After a production release, merge `main` → `development` using a **merge
+     commit** (not rebase).
+   - An automated CI job opens this PR; see
+     [Automated Back-Merge](#automated-back-merge).
+   - If the auto-PR has conflicts, resolve manually:
+     ```bash
+     git checkout development
+     git pull origin development
+     git merge origin/main
+     # Resolve conflicts, then push
+     git push origin development
+     ```
+
+## Hotfix Flow
+
+Hotfixes bypass the normal `development → staging → main` promotion path to get
+urgent fixes into production quickly. **EPA staff only** for the merge and
+deploy steps.
+
+1. **Branch from `main`**
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b hotfix/<issue-description>
+   ```
+2. **Implement and validate locally**
+   - Fix the issue and test with `ddev drush deploy -y` and
+     `ddev drush config:status`.
+   - Follow the same code-quality checks as any other PR.
+3. **Open a PR targeting `main`**
+   - Requires at least one maintainer approval.
+   - The PR description should explain the urgency and exactly what is broken in
+     production.
+4. **Merge into `main`** (merge commit, do not squash).
+5. **Tag and deploy to production**
+   - The release manager tags the hotfix on `main` (see
+     [Release Tagging Process](#release-tagging-process)).
+   - Sync the GitLab mirror (manual sync — do not wait for auto-sync).
+   - Trigger the production pipeline manually on GitLab (`main` branch).
+   - Monitor the pipeline to completion and verify the production site.
+6. **Sync the fix to `staging` and `development`**
+   - Cherry-pick or merge the hotfix into `staging`:
+     ```bash
+     git checkout staging
+     git pull origin staging
+     git cherry-pick <hotfix-merge-commit-sha>
+     git push origin staging
+     ```
+   - The automated back-merge job opens a PR from `main` → `development`. If it
+     does not cover the fix (e.g., due to conflicts), cherry-pick into
+     `development` manually.
+   - **All three long-lived branches (`main`, `staging`, `development`) must
+     contain the hotfix before the next sprint cycle.**
+7. **Communicate** — announce the hotfix and its deployment in #webcms-dev.
+
+## Why Branch From `development`?
+
+- **Continuous integration:** Features integrate in the active development
+  branch, the way GitHub Flow / Git Flow intend.
+- **Early conflict detection:** Features see each other immediately, catching
+  integration issues during development rather than at PR time.
+- **Simplified workflow:** No need for developers to manually rebase against a
+  `development` that has diverged from `main`.
+- **Natural integration:** Multiple features can be tested together in the dev
+  environment before promotion.
+- **Aligned with the deployment model:** The branch you develop in is the branch
+  that deploys to dev.
+
+## Merge Strategy
+
+The merge method is deliberate and differs by the kind of merge:
+
+| Merge | Method | Why |
+|-------|--------|-----|
+| Feature/bugfix PR → `development` | **Squash or rebase** | Keeps a clean, linear history on the integration branch. |
+| `development` → `staging` | **Merge commit** | A release maps to one identifiable merge. |
+| `staging` → `main` | **Merge commit** | Preserves the exact stage-tested state as a single production merge. |
+| Hotfix → `main` | **Merge commit** (never squash) | Keeps the hotfix commits intact for cherry-picking to `staging`/`development`. |
+| `main` → `development` (back-merge) | **Merge commit** (not rebase, not fast-forward) | Preserves commit hashes on `development` so no one's local branch is invalidated; the merge commit is the audit trail for when production state synced back. |
+
+## Commit Message Convention
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+`chore`.
+
+When a change has a tracking issue, reference it in the subject or footer so the
+commit links back to the work item.
+
+Examples:
+
+```bash
+git commit -m "feat(workflow): add approval step for content editors"
+git commit -m "fix(theme): correct responsive menu breakpoint"
+git commit -m "docs: update deployment guide with skip-build instructions"
+```
+
+Write commit messages and PR descriptions in your own words, and read anything
+you are about to submit before you submit it. A description is a request for
+someone else's time — make sure it is accurate and that you have validated every
+claim in it.
+
+## Pull Request Guidelines
+
+- **Target branches:** Feature/bugfix work → `development`; hotfixes → `main`.
+- **Use the template:** Fill out the
+  [pull request template](../.github/pull_request_template.md), including the
+  tracking issue link.
+- **Keep PRs reviewable** (roughly less than a day of work). Several small PRs
+  beat one large one. Use draft PRs for early feedback.
+- **Run the local gates first:** `ddev drush updb`, `ddev drush cex`,
+  `ddev composer phpcs`, `ddev composer phpstan`, theme builds, and relevant
+  tests before requesting review.
+- **Provide evidence:** Include notes on how you manually tested, rationale for
+  specific implementation choices, and screenshots or a screen recording for
+  visual changes. The reviewer should be able to see that the work was validated
+  before it reached them.
+- **Require at least one maintainer approval.**
+- **Do not bundle unrelated module updates** into one PR, unless they are
+  genuinely coupled (for example, `metatag` and `metatag_schema`).
+- **Configuration changes travel with code.** Never commit configuration in code
+  and database simultaneously, and follow the
+  [Config Sync Workflow](../services/drupal/CONFIG_SYNC_WORKFLOW.md) when adding
+  or removing modules.
+
+## Release Cadence & Coordination
+
+- **Daily dev deploys:** Merge PRs into `development` as they are approved. Use
+  skip-build for quick iterations; run one full build per day or after any
+  dependency change.
+- **Stage deploys:** At least once per sprint (or as needed). Merge
+  `development` → `staging`, let the stage pipeline run, and perform QA.
+- **Production deploys:** After stage QA sign-off, follow the
+  [Stage-to-Production Promotion Checklist](#stage-to-production-promotion-checklist).
+  The release manager tags the release on `staging` and triggers the production
+  pipeline on GitLab after merging to `main`.
+- **Back-merge:** After each production release, immediately merge
+  `main` → `development` (merge commit). An automated CI job opens this PR.
+
+## Release Tagging Process
+
+The release manager (Michael Hessling) creates the release tag on `staging`
+**before** merging to `main`. The tag marks the exact commit whose Docker images
+were built and tested on stage — this is the audit trail linking what was tested
+to what gets deployed.
+
+**Tag format:** `vYYYY.MM.DD` (for example, `v2026.04.09`). For multiple
+same-day releases, append a sequence number: `v2026.04.09.2`.
+
+**Steps:**
+
+1. Confirm stage QA is complete and sign-off is received.
+2. Tag the release on `staging`:
+   ```bash
+   git checkout staging
+   git pull origin staging
+   git tag -a vYYYY.MM.DD -m "Release vYYYY.MM.DD: <brief summary>"
+   git push origin vYYYY.MM.DD
+   ```
+3. Merge `staging` → `main` via PR (merge commit).
+4. Sync the GitLab mirror and trigger the production pipeline on GitLab (`main`
+   branch). The production pipeline promotes the images built from the tagged
+   staging commit — no rebuild.
+
+## Stage-to-Production Promotion Checklist
+
+Follow this checklist when promoting from stage to production. **All steps are
+EPA staff only.**
+
+**Pre-Promotion:**
+
+- [ ] Stage QA is complete
+- [ ] Stakeholder sign-off received
+- [ ] No outstanding critical bugs on stage
+- [ ] If a freeze is needed, initiate the [Freeze Protocol](#freeze-protocol)
+- [ ] Announce the planned production deployment in #webcms-dev
+
+**Promotion:**
+
+- [ ] Release manager tags the release on `staging` (see
+      [Release Tagging Process](#release-tagging-process))
+- [ ] Create PR: `staging` → `main` on GitHub
+- [ ] Review the PR — verify it contains only the expected changes
+- [ ] Merge the PR using a merge commit (do not squash)
+- [ ] Sync the GitLab mirror
+- [ ] Trigger the production pipeline manually on GitLab (`main` branch)
+- [ ] Monitor the pipeline to completion
+
+**Post-Promotion:**
+
+- [ ] Verify the production site is healthy (smoke test key pages and workflows)
+- [ ] Confirm the ECS service updated in the AWS Console
+- [ ] Merge the automated back-merge PR (`main` → `development`); resolve
+      conflicts if any
+- [ ] Announce deployment complete in #webcms-dev
+- [ ] If a freeze was in effect, lift it
+
+## Freeze Protocol
+
+A code freeze restricts merges to stabilize the codebase before a production
+release.
+
+**Initiating a freeze:**
+
+1. The release manager (Michael Hessling) announces the freeze in #webcms-dev
+   with the expected duration and target release date.
+2. During the freeze, **no new PRs are merged into `development`** except:
+   - Critical bug fixes required for the release
+   - Documentation-only changes
+3. In-progress feature branches should be rebased on `development` but held until
+   the freeze lifts.
+
+**During the freeze:**
+
+1. QA and validation happen on the `staging` (stage) environment.
+2. Critical fixes follow the [hotfix flow](#hotfix-flow): branch from `main` or
+   `staging`, fix, PR, merge.
+3. All hotfixes merged during the freeze must be communicated in #webcms-dev.
+
+**Lifting the freeze:**
+
+1. The production release is deployed and verified.
+2. Back-merge `main` → `development` (merge commit) to incorporate freeze-period
+   hotfixes.
+3. The release manager announces the freeze is lifted in #webcms-dev.
+4. Held PRs can resume merging into `development`.
+
+## Automated Back-Merge
+
+To prevent `development` from drifting behind `main`, a GitLab CI job
+automatically opens a GitHub PR from `main` → `development` after any push to
+`main`.
+
+**How it works:**
+
+1. When the GitLab mirror syncs a new commit on `main`, the `open-backmerge-pr`
+   CI job runs.
+2. The job checks for an existing open back-merge PR to avoid duplicates.
+3. If none exists, it creates a PR from `main` → `development` via the GitHub
+   API.
+4. The team reviews and merges the PR. If there are conflicts, a developer
+   resolves them manually.
+
+**GitLab CI job** (implemented in `.gitlab-ci.yml`):
+
+```yaml
+open-backmerge-pr:
+  stage: .post
+  image: alpine:latest
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+  before_script:
+    - apk add --no-cache curl jq
+  script:
+    - |
+      EXISTING=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+        "https://api.github.com/repos/USEPA/webcms/pulls?head=USEPA:main&base=development&state=open" \
+        | jq length)
+      if [ "$EXISTING" -gt 0 ]; then
+        echo "Back-merge PR already exists, skipping."
+        exit 0
+      fi
+      curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+        -H "Content-Type: application/json" \
+        "https://api.github.com/repos/USEPA/webcms/pulls" \
+        -d '{
+          "title": "chore: back-merge main into development",
+          "body": "Automated back-merge to sync production state into development after release.",
+          "head": "main",
+          "base": "development"
+        }'
+  allow_failure: true
+```
+
+**Required setup:**
+
+- Add `GITHUB_TOKEN` as a protected, masked CI/CD variable in GitLab
+  (Settings → CI/CD → Variables) with `repo` scope.
+
+## Branch Protection Configuration
+
+GitHub branch protection rules for this repository. Audit these periodically to
+ensure they remain in effect.
+
+**To configure:** GitHub → Repository Settings → Branches → Branch protection
+rules.
+
+### `main` (production)
+
+- Require a pull request before merging
+  - Required approvals: **1** (maintainer)
+  - Dismiss stale pull request approvals when new commits are pushed
+- Require status checks to pass before merging
+- Require branches to be up to date before merging
+- Do not allow force pushes
+- Do not allow deletions
+- Restrict who can push: EPA staff / repository maintainers only
+
+### `staging` (stage)
+
+- Require a pull request before merging
+  - Required approvals: **1** (maintainer)
+- Require status checks to pass before merging
+- Do not allow force pushes
+- Do not allow deletions
+- Restrict who can push: EPA staff / repository maintainers only
+
+### `development` (dev)
+
+- Require a pull request before merging
+  - Required approvals: **1**
+- Do not allow force pushes
+
+### Feature branches (`feature/*`, `bugfix/*`, `hotfix/*`)
+
+- No branch protection rules required
+- Developers manage their own branches
+- Delete branches after merge
+
+## Roles & Responsibilities
+
+| Role | Who | Responsibilities |
+|------|-----|------------------|
+| Contributor | All developers and middleware engineers | Branch from `development`, open well-evidenced PRs, respond to review, keep configuration and code in sync. |
+| Maintainer / Reviewer | Repository maintainers | Review and approve PRs, enforce the merge strategy, ensure branch protection holds. |
+| Release manager | Michael Hessling | Tag releases, run the stage-to-production promotion, declare and lift freezes, trigger production pipelines. |
+
+Promotion to `staging` and `main`, production pipeline triggers, and release
+tagging are **EPA staff only**. Contractors and middleware engineers contribute
+through `development` and PRs; they do not merge to or deploy from `staging` or
+`main`.
+
+## FAQs
+
+- **Why not branch from `main` directly?** Branching from `main` causes feature
+  branches to diverge from active development work. By the time a feature is
+  ready, it is missing weeks of changes merged to `development`, leading to
+  late-stage conflicts.
+- **Can I deploy from a feature branch?** No. Only `development` (dev) and
+  `staging` (stage) trigger automatic deployments. Production deploys from `main`
+  via a manual pipeline trigger.
+- **What if a feature spans multiple sprints?** Periodically rebase on
+  `development` to stay current with integrated work. Use feature flags for
+  incomplete functionality.
+- **How do freeze periods work?** See the [Freeze Protocol](#freeze-protocol) for
+  the full process.
+- **Who can tag a release or deploy to production?** The release manager, and
+  EPA staff only. See [Roles & Responsibilities](#roles--responsibilities).

--- a/docs/cicd-pipeline.md
+++ b/docs/cicd-pipeline.md
@@ -1,0 +1,227 @@
+# CI/CD Pipeline
+
+This document explains how code becomes a running environment for the EPA
+WebCMS. It is an overview and index; the **authoritative configuration** is
+[`.gitlab-ci.yml`](../.gitlab-ci.yml) and the includes under
+[`.gitlab/`](../.gitlab). Where this document and the pipeline configuration
+disagree, the configuration wins — update this document to match.
+
+For the branching and promotion rules that drive the pipeline, see
+[docs/GIT_WORKFLOW.md](GIT_WORKFLOW.md). For the day-to-day deploy commands, see
+[CONTRIBUTING.md](../CONTRIBUTING.md#deployment-guide).
+
+## Table of Contents
+
+- [Architecture](#architecture)
+- [Branch-to-Environment Mapping](#branch-to-environment-mapping)
+- [Pipeline Stages](#pipeline-stages)
+- [How a Pipeline Is Triggered](#how-a-pipeline-is-triggered)
+- [Build Once, Deploy Many](#build-once-deploy-many)
+- [Skip-Build & Build Detection](#skip-build--build-detection)
+- [Security Scanning](#security-scanning)
+- [Advanced Pipeline Variables](#advanced-pipeline-variables)
+- [Notifications](#notifications)
+- [Automated Back-Merge](#automated-back-merge)
+- [Performance Optimizations](#performance-optimizations)
+- [Troubleshooting](#troubleshooting)
+- [Reference Map](#reference-map)
+
+## Architecture
+
+Code is hosted on GitHub and deployed through a GitLab mirror into AWS ECS:
+
+```
+GitHub (USEPA/webcms)
+    │  mirror sync (every ~30 min, or manual "Update now")
+    ▼
+GitLab (drupalcloud/drupalclouddeployment)
+    │  CI/CD pipeline (.gitlab-ci.yml)
+    ▼
+AWS ECS (Fargate) — dev, stage, and production services
+```
+
+- **GitHub** is the source of truth: all development, review, and version
+  history live here.
+- **GitLab** holds the infrastructure runners and orchestrates builds and
+  deployments. It pulls from the GitHub mirror.
+- **AWS ECS** runs the application. Each site/language pair (English and Spanish)
+  is its own ECS service; deployments are rolling and zero-downtime.
+
+Because the GitLab mirror does not auto-trigger pipelines (a deliberate
+permission restriction), deployments are triggered explicitly — by
+[`push-dev.sh`](../push-dev.sh), [`trigger-pipeline.sh`](../trigger-pipeline.sh),
+or the GitLab pipeline UI. See
+[`.gitlab/DEPLOYMENT_WORKFLOW.md`](../.gitlab/DEPLOYMENT_WORKFLOW.md) for the
+step-by-step manual flow.
+
+## Branch-to-Environment Mapping
+
+| Branch | Environment | Trigger | Security scans | Typical duration |
+|--------|-------------|---------|----------------|------------------|
+| `development` | Dev | Automatic via `push-dev.sh` | No (kept fast) | ~10–15 min full build; ~3–5 min skip-build |
+| `staging` | Stage | Push to `staging` (manual promotion) | Yes (SAST, dependency, secret, image) | ~25–35 min |
+| `main` | Production | Manual pipeline trigger on GitLab | Promotes stage-tested images (no rebuild) | ~5–10 min |
+
+The `development` branch trades security scanning for speed; the `staging` branch
+runs the full security suite before anything is eligible for production. See
+[Security Scanning](#security-scanning).
+
+## Pipeline Stages
+
+The pipeline defines the following stages (from
+[`.gitlab-ci.yml`](../.gitlab-ci.yml)). Which stages actually run depends on the
+branch and on pipeline variables.
+
+| Stage | Purpose | Runs on |
+|-------|---------|---------|
+| `Build` | Build the `drupal`, `nginx`, and `drush` Docker images (Kaniko) | All branches (skippable — see [Skip-Build](#skip-build--build-detection)) |
+| `Test` | SAST, dependency scanning, secret detection | `staging` only |
+| `Scan` | Prisma Cloud image vulnerability scanning | `staging` only |
+| `Infrastructure:Preprod:Init/Validate/Plan/Apply` | Provision/adjust shared preproduction infrastructure via Terraform (apply requires manual approval) | `staging` |
+| `Deploy:Dev:Init/Validate/Plan/Apply` | Terraform deploy to the dev ECS services | `development`; or `staging` when `DEPLOY_TO_DEV=true` (manual) |
+| `Deploy:Stage:Init/Validate/Plan/Apply` | Terraform deploy to the stage ECS services (English + Spanish, parallel) | `staging` |
+| `Update` | Drush database updates and config import via ECS tasks (parallel by site/language) | After a successful deploy |
+| `Artifacts` | Create deployment artifacts | After deploy |
+| `Release` | Create GitLab releases | After deploy |
+
+The deploy stages follow the standard Terraform lifecycle — **Init → Validate →
+Plan → Apply** — so every infrastructure change is planned before it is applied.
+The `Update` stage runs `drush deploy` semantics (database updates, config
+import, cache rebuild) against the freshly deployed containers; see
+[`ci/README.md`](../ci/README.md) for the ECS Drush automation that drives it.
+
+## How a Pipeline Is Triggered
+
+Pipelines are created only for the sources allowed by the `workflow:` rules in
+[`.gitlab-ci.yml`](../.gitlab-ci.yml): `push` (includes mirror updates), `web`
+(manual UI run), `api`, `trigger`, `schedule`, and tag creation. Everything else
+is rejected.
+
+The typical paths:
+
+- **Dev:** `./push-dev.sh` from your machine. It pushes to GitHub, helps sync the
+  mirror, and triggers the `development` pipeline. It also auto-detects whether a
+  full build is needed (see below).
+- **Stage:** push to the `staging` branch; the stage pipeline runs automatically.
+- **Production:** sync the mirror and trigger the pipeline manually on the `main`
+  branch in the GitLab UI.
+
+## Build Once, Deploy Many
+
+A core safety property of this pipeline: **the images deployed to production are
+the same images that were built and tested on stage.**
+
+1. The `staging` pipeline builds the Docker images and runs the full security
+   suite against them.
+2. The release is tagged on `staging` (see
+   [Release Tagging Process](GIT_WORKFLOW.md#release-tagging-process)).
+3. The `main` (production) pipeline **promotes** those tagged images — it does
+   not rebuild. This guarantees production runs exactly what stage validated.
+
+## Skip-Build & Build Detection
+
+For the `development` branch, rebuilding Docker images is often unnecessary —
+many changes (custom modules, config, Twig templates, docs) do not affect the
+image. `push-dev.sh` analyzes the changed files and chooses automatically:
+
+- **Full build** when build-affecting files change: `composer.json` /
+  `composer.lock` / `composer.patches.json`, theme source (`*.scss`, `*.js`,
+  `source/`, Gulp config), `package.json` / `package-lock.json`, any
+  `Dockerfile`, build scripts, `docker-compose*`, or `.gitlab-ci.yml`.
+- **Deploy-only** (reuse `:development-latest` images) for everything else:
+  custom modules, `config/`, Drush commands, non-compiled Twig/PHP templates,
+  and documentation.
+
+Manual overrides: `./push-dev.sh --force-build` and `./push-dev.sh --skip-build`.
+You can also set `SKIP_BUILD=true` directly when triggering a pipeline from the
+GitLab UI. Full detail and examples live in
+[CONTRIBUTING.md](../CONTRIBUTING.md#automatic-build-detection--skip-build-deployments).
+
+> Removing a Composer module is always a full build, and must follow the
+> [Config Sync Workflow](../services/drupal/CONFIG_SYNC_WORKFLOW.md) — never
+> skip-build a module removal.
+
+## Security Scanning
+
+Security scanning runs on the **`staging` branch only**, so that everything bound
+for production is scanned, while the dev branch stays fast.
+
+- **Test stage:** SAST (Semgrep), Dependency Scanning (Gemnasium), Secret
+  Detection — included from GitLab's built-in templates.
+- **Scan stage:** Prisma Cloud image scanning for the `drupal`, `nginx`, and
+  `drush` containers.
+
+GitLab's security templates expose **configuration-only** parent jobs (`sast`,
+`dependency_scanning`, `secret_detection`) that must not be given executable
+`rules`, plus executable analyzer jobs (`semgrep-sast`,
+`gemnasium-dependency_scanning`, `secret_detection`) where branch rules belong.
+Getting this wrong produces *"job is used for configuration only"* errors. The
+full root-cause analysis and the safe override pattern are documented in
+[`.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md`](../.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md).
+
+## Advanced Pipeline Variables
+
+Set these as CI/CD variables when triggering a pipeline from the GitLab UI
+(Pipelines → Run pipeline).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `SKIP_BUILD` | `false` | Skip the `Build` stage and reuse `:development-latest` images. |
+| `DEPLOY_TO_DEV` | `false` | On the `staging` branch, also build for and deploy to dev (the dev deploy job stays **manual**). Ignored on `development`. |
+| `WEBCMS_SITE_FILTER` | unset | On the `staging` branch, restrict deployment to a single site: `stage` (stage English + Spanish) or `dev` (dev only, with `DEPLOY_TO_DEV=true`). Ignored on `development`. |
+
+`DEPLOY_TO_DEV` and `WEBCMS_SITE_FILTER` are documented with worked examples in
+[README.md → Advanced Pipeline Variables](../README.md#advanced-pipeline-variables)
+and [CONTRIBUTING.md → Advanced Pipeline Variables](../CONTRIBUTING.md#advanced-pipeline-variables).
+
+## Notifications
+
+The pipeline posts Microsoft Teams notifications for major events (pipeline
+started, build success/failure, manual approval required, deployment lifecycle,
+security scan issues, pipeline completed). Notifications are driven by the
+`TEAMS_WEBHOOK_URL` CI/CD variable and the jobs in
+[`.gitlab/teams-notifications.yml`](../.gitlab/teams-notifications.yml). Setup and
+troubleshooting: [`.gitlab/TEAMS_NOTIFICATIONS.md`](../.gitlab/TEAMS_NOTIFICATIONS.md).
+
+## Automated Back-Merge
+
+After any push to `main`, the `open-backmerge-pr` job opens a GitHub PR from
+`main` → `development` so the integration branch never drifts behind production.
+It is idempotent (skips if an open back-merge PR already exists). See
+[docs/GIT_WORKFLOW.md → Automated Back-Merge](GIT_WORKFLOW.md#automated-back-merge)
+for the job definition and required `GITHUB_TOKEN` setup.
+
+## Performance Optimizations
+
+The development path is tuned to be substantially faster than stage by building
+fewer images, skipping security scanning, parallelizing Terraform validation,
+and reusing cached layers (Kaniko `--cache-ttl=168h`). The dev pipeline runs in
+roughly 10–15 minutes versus 25–35 for stage. The full list of optimizations,
+their locations in `.gitlab-ci.yml`, and the safety rationale are in
+[`.gitlab/PIPELINE_OPTIMIZATIONS.md`](../.gitlab/PIPELINE_OPTIMIZATIONS.md).
+
+## Troubleshooting
+
+| Symptom | Where to look |
+|---------|---------------|
+| Pipeline did not start after a push | Mirror not synced yet — sync manually, then re-trigger. See [`.gitlab/DEPLOYMENT_WORKFLOW.md`](../.gitlab/DEPLOYMENT_WORKFLOW.md). |
+| `push-dev.sh` runs but no pipeline appears | GitLab token expired/invalid, or mirror not synced. See [CONTRIBUTING.md → Troubleshooting](../CONTRIBUTING.md#gitlab-pipeline-fails-to-trigger). |
+| Pipeline rejected before any job runs | GitLab CI config merge issue (often a security-template override). See [`.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md`](../.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md). |
+| Skip-build deploy fails with "image not found" | No `:development-latest` image yet — run a full build first (`./push-dev.sh`). |
+| Changes deployed but not visible | Browser or Drupal cache, or wrong image deployed. See [CONTRIBUTING.md → Troubleshooting](../CONTRIBUTING.md#changes-not-visible-after-deployment). |
+| Deployment failed mid-pipeline | Open the failed job's logs; common causes: AWS credentials expired, Terraform state locked, Docker build error. |
+
+## Reference Map
+
+| Topic | Authoritative source |
+|-------|----------------------|
+| Full pipeline definition | [`.gitlab-ci.yml`](../.gitlab-ci.yml) |
+| Docker build jobs | [`.gitlab/docker.yml`](../.gitlab/docker.yml) |
+| Terraform jobs | [`.gitlab/terraform.yml`](../.gitlab/terraform.yml) |
+| Teams notifications | [`.gitlab/teams-notifications.yml`](../.gitlab/teams-notifications.yml), [`.gitlab/TEAMS_NOTIFICATIONS.md`](../.gitlab/TEAMS_NOTIFICATIONS.md) |
+| Manual deploy flow | [`.gitlab/DEPLOYMENT_WORKFLOW.md`](../.gitlab/DEPLOYMENT_WORKFLOW.md) |
+| Pipeline optimizations | [`.gitlab/PIPELINE_OPTIMIZATIONS.md`](../.gitlab/PIPELINE_OPTIMIZATIONS.md) |
+| Security scanning gotchas | [`.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md`](../.gitlab/SECURITY_SCANNING_TROUBLESHOOTING.md) |
+| ECS Drush update automation | [`ci/README.md`](../ci/README.md) |
+| Branching & releases | [docs/GIT_WORKFLOW.md](GIT_WORKFLOW.md) |
+| Infrastructure (Terraform) | [terraform/infrastructure/README.md](../terraform/infrastructure/README.md), [terraform/webcms/README.md](../terraform/webcms/README.md) |


### PR DESCRIPTION
## Description

Raises the contributor and workflow documentation to an enterprise-grade standard while **preserving the existing multi-environment branching model** (feature → development → staging → main) and all current functionality. This is a documentation-and-governance change only — no application code or configuration is touched.

### Added
- **`docs/GIT_WORKFLOW.md`** — authoritative branching, merging, promotion, hotfix, freeze, release-tagging, automated back-merge, branch-protection, and roles & responsibilities reference. Codifies **Jira (project `WEBCMS`, jira.epa.gov) as the system of record**, with the issue key carried on every branch, commit, and PR.
- **`docs/cicd-pipeline.md`** — CI/CD overview of the GitHub → GitLab → AWS ECS pipeline: stages, branch mapping, build-once-deploy-many, skip-build, security scanning, pipeline variables, and a source reference map.
- **`SECURITY.md`** — vulnerability reporting policy and scope.
- **`.github/CODEOWNERS`** — review routing across docs, CI/CD, infrastructure, and Drupal configuration.
- **`CHANGELOG.md`** — Keep a Changelog format with date-based release tags.
- **`LICENSE.md`** — MIT, matching the EPA standard used across EPA repositories.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank GitHub issues and redirects reporters to Jira (WEBCMS), Slack, security, and the GitLab pipeline tracker.

### Changed
- **`CONTRIBUTING.md`** — condensed the inline Git Workflow into a quick reference that links to `docs/GIT_WORKFLOW.md`; expanded Additional Resources into a full documentation index; pointed Getting Help at Jira; corrected the documentation and license references.
- **`README.md`** — corrected the documentation index; linked the Git Workflow and CI/CD pipeline docs.
- **`.github/pull_request_template.md`** — expanded with the Jira issue link, change type, target branch, testing evidence, configuration/deployment, and a reviewer checklist.

### Fixed
- Removed broken documentation links (a non-existent `WARP.md` reference in `README.md`, and `docs/` references in `CONTRIBUTING.md` that pointed at files that did not exist).

## Testing Done
- Verified all relative Markdown links in the new and changed docs resolve to real files.
- Confirmed `LICENSE.md` is byte-identical to the EPA standard MIT license used in sibling repos.
- Confirmed the Jira host (`jira.epa.gov`) is consistent across `CONTRIBUTING.md`, `docs/GIT_WORKFLOW.md`, the PR template, and `ISSUE_TEMPLATE/config.yml`.

## Notes for Reviewers
- Branch protection settings and CODEOWNERS handles are documented as the intended state; confirm the GitHub team/handles match current maintainers and adjust if needed.
- No build is required for this change (documentation only).