### PR TITLE
MOB-2155: Fix Flysystem HeadBucket error by guarding the s3-snapshot scheme on a configured bucket

### DIFF
--- a/services/drupal/web/sites/default/settings.snapshot.php
+++ b/services/drupal/web/sites/default/settings.snapshot.php
@@ -2,7 +2,18 @@
 
 /**
  * Create s3 stream wrapper for snapshots.
+ *
+ * Bail out early when no snapshot bucket is configured. When
+ * WEBCMS_S3_SNAPSHOT_BUCKET is unset, getenv() returns FALSE, which the
+ * flysystem_s3 adapter would otherwise pass to the AWS SDK HeadBucket call as
+ * Bucket => false. That fails input validation and breaks both the Flysystem
+ * cron job and the site status report on every environment that does not run
+ * snapshots.
  */
+if (empty(getenv('WEBCMS_S3_SNAPSHOT_BUCKET'))) {
+  return;
+}
+
 $schemes = [
   's3-snapshot' => [
     'driver' => 's3',


### PR DESCRIPTION
## Description

Our Flysystem cron job has been failing — and was disabled to stop the noise — because of this error:

`Found 1 error while validating the input provided for the HeadBucket operation: [Bucket] must be a string or an object that implements __toString(). Found bool(false)`

The status report also shows "Flysystem: s3-snapshot Bucket does not exist."

This PR makes the s3-snapshot Flysystem scheme register only when a snapshot bucket is actually configured, which clears the error on every environment that doesn't run snapshots and lets us re-enable the Flysystem cron.

## Root cause
This is not the epa_snapshot module (it's disabled everywhere). The broken scheme is wired up in settings, independent of that module:

1. services/drupal/web/sites/default/settings.php includes settings.snapshot.php unconditionally whenever the file exists — it's committed, so that's every environment.
2. settings.snapshot.php registers the s3-snapshot scheme with 'bucket' => getenv('WEBCMS_S3_SNAPSHOT_BUCKET').
3. Terraform only injects WEBCMS_S3_SNAPSHOT_BUCKET when drupal_en_snapshot_bucket is non-null (terraform/webcms/shared.tf). It defaults to null and we don't set it, so the var is never present.
4. getenv() on an unset var returns boolean false (not ""), so the scheme ends up as 'bucket' => false.
5. flysystem/flysystem_s3 are enabled and probe every scheme. The S3 adapter calls doesBucketExist() → HeadBucket with Bucket => false, which fails AWS SDK input validation. That's the exception and the status-report warning, and what kept killing the cron job.

## Change
Added an early return to settings.snapshot.php so the scheme + Tome settings only register when a bucket is set:

```
if (empty(getenv('WEBCMS_S3_SNAPSHOT_BUCKET'))) {
  return;
}

// existing s3-snapshot scheme + tome_static settings only run below this point
```
•  The error was a symptom of vestigial config — we were registering a stream wrapper for a feature that's fully dormant here. "No bucket → no scheme" is the correct state.
•  No regression for the working case: if WEBCMS_S3_SNAPSHOT_BUCKET is set, the guard falls through and everything registers as before.
•  Narrowly scoped: it only short-circuits when the var is empty. A real-but-wrong bucket name will still surface a legitimate "bucket does not exist" error.

## What this doesn't address / follow-ups
•  Doesn't restore snapshots. Bringing them back still requires provisioning the bucket, setting drupal_en_snapshot_bucket in Terraform, and enabling epa_snapshot/tome_static.
•  Trades a loud signal for a silent one in one hypothetical: an env that should run snapshots but is missing the bucket will now silently have no snapshot capability instead of erroring on the status report. Acceptable given snapshots are intentionally off, but noting it.
•  Deeper smell remains: settings.php includes settings.snapshot.php based purely on file existence, decoupled from whether the feature is on. The env-var guard is a pragmatic proxy; longer term we could gate the whole stack on one explicit signal.
•  Re-enable the Flysystem cron job in ultimate_cron after this deploys.

## Testing
With WEBCMS_S3_SNAPSHOT_BUCKET unset: settings.snapshot.php returns early, no s3-snapshot scheme registered, status report is clean, no HeadBucket exception.
With WEBCMS_S3_SNAPSHOT_BUCKET set: scheme + Tome settings register exactly as before.
Flysystem cron runs without the validation error.