### PR TITLE
docs: Clarify intentional fall-through for 'migration' env in setting…

### DIFF
--- a/services/drupal/web/sites/default/settings.php
+++ b/services/drupal/web/sites/default/settings.php
@@ -843,6 +843,8 @@ switch ($env_state) {
   case 'migration':
     $config['purge.plugins']['queuers'] = [['plugin_id'=> 'coretags', 'status' => false]];
     $config['auto_entitylabel.settings.node.faq']['status'] = 0;
+    // Intentional fall through: 'migration' also needs the 'run' memcache/cache
+    // backend setup below, so we deliberately omit a break here.
   case 'run':
     // Convert the comma-separated list of ElastiCache endpoints to memcache's expected server format
     $memcached_nodes = getenv('WEBCMS_CACHE_HOSTS');


### PR DESCRIPTION
Document intentional migration → run switch fall-through in settings.php

The $env_state switch in services/drupal/web/sites/default/settings.php deliberately falls through from case 'migration' into case 'run', but there was no break and no comment marking it intentional. This PR adds an explicit fall-through comment so it doesn't read as a bug (and doesn't get "fixed" by accident).

The OG problem:
```
switch ($env_state) {
  case 'migration':
    $config['purge.plugins']['queuers'] = [['plugin_id' => 'coretags', 'status' => false]];
    $config['auto_entitylabel.settings.node.faq']['status'] = 0;
  case 'run':            // <-- migration silently falls through to here
    // ... memcache / cache backend setup ...
    break;
}
```

The fall-through is intentional (migration needs the same cache setup as run), but nothing said so.

The change:
  case 'migration':
    ```
$config['purge.plugins']['queuers'] = [['plugin_id' => 'coretags', 'status' => false]];
    $config['auto_entitylabel.settings.node.faq']['status'] = 0;
    // Intentional fall through: 'migration' also needs the 'run' memcache/cache
    // backend setup below, so we deliberately omit a break here.
  case 'run':
```

Migration runs its own extra config (the purge queuer + auto-entitylabel disable) before it needs the shared memcache setup, so case 'migration': case 'run': stacked together wouldn't preserve behavior. The documented fall-through is the correct structure.