### PR TITLE
Revert "Feature: MOB-2130, Aligning PHP version for all services"

### DIFF
--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/php:8.3.31-fpm-alpine3.23 AS base
+FROM public.ecr.aws/docker/library/php:8.3.29-fpm-alpine3.22 AS base
 
 # Bump system packages
 RUN apk upgrade
@@ -121,7 +121,7 @@ RUN composer install \
 RUN rm auth.json
 
 # Build Gesso, the WebCMS' theme
-FROM forumone/gesso:node-v24-php-8.3 AS gesso
+FROM forumone/gesso:node-v18-php-8.1 AS gesso
 
 WORKDIR /app
 

--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -153,7 +153,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.2",
         "briancherne/jquery-hoverintent": "^1.10",
         "ckeditor-plugin/fakeobjects": "^4.15",
         "ckeditor-plugin/iframe": "^4.15",
@@ -350,7 +350,7 @@
             "ext-gd": "1.0.0",
             "ext-opcache": "1.0.0",
             "ext-pdo": "1.0.0",
-            "php": "8.3"
+            "php": "8.2"
         },
         "allow-plugins": {
             "composer/installers": true,


### PR DESCRIPTION
Reverts WEBSUP-2130. Updating PHP to all be v8.3.x broke a module dependency (the installed version (8.x-1.9) of drupal/diff has a library that requires PHPv8.2--need to update diff to at least 8.x-1.10).