### PR TITLE
WEBCMS-311 Paragraph button in ckeditor not working, fixed

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -258,7 +258,7 @@
         "drupal/optional_end_date": "^1.4",
         "drupal/page_manager": "^4.0@RC",
         "drupal/paragraphs": "^1.19",
-        "drupal/paragraphs_entity_embed": "^4.0@beta",
+        "drupal/paragraphs_entity_embed": "^4.0",
         "drupal/pathauto": "^1.13",
         "drupal/pathologic": "^2.0@alpha",
         "drupal/queue_ui": "^3.2",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "487a8400a601eea1bac334b20e55291d",
+    "content-hash": "c1e1641e8e50456d106c29f182c448fa",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8063,17 +8063,17 @@
         },
         {
             "name": "drupal/paragraphs_entity_embed",
-            "version": "4.0.0-beta1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs_entity_embed.git",
-                "reference": "4.0.0-beta1"
+                "reference": "4.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs_entity_embed-4.0.0-beta1.zip",
-                "reference": "4.0.0-beta1",
-                "shasum": "1d18368a6b724184aea8410c6a9708f69c5f65e6"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs_entity_embed-4.0.0.zip",
+                "reference": "4.0.0",
+                "shasum": "b1aa6cc1d221e3ee749568875a0c73483f4f8e51"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11",
@@ -8090,11 +8090,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.0-beta1",
-                    "datestamp": "1738611577",
+                    "version": "4.0.0",
+                    "datestamp": "1774978322",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -25322,7 +25322,6 @@
         "drupal/limited_field_widgets": 10,
         "drupal/linkit_telephone": 20,
         "drupal/page_manager": 5,
-        "drupal/paragraphs_entity_embed": 10,
         "drupal/pathologic": 15,
         "drupal/role_expose": 20,
         "drupal/smart_date": 10,


### PR DESCRIPTION
Closes https://jira.epa.gov/browse/WEBCMS-311

## Description

Paragraph button in CKEditor was not working, it was throwing an error in the browser console. 

Installed version of paragraph_entity_embed was 4.0.0-beta. The latest version is 4.0.0. Upgrading the module to the latest fixed the issue.

