### PR TITLE
WEBCMS-311 Remove patch as it is already merged into 4.0.0 version of…

### DIFF
--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -133,10 +133,6 @@
     "drupal/linkit": {
       "Editing links does not remove possible stale data- attributes": "https://www.drupal.org/files/issues/2021-08-09/linkit_rename-stale-data-attributes_3111578-3.patch"
     },
-    "drupal/paragraphs_entity_embed": {
-      "Prevent the reuse of embedded paragraphs": "https://www.drupal.org/files/issues/2020-04-30/paragraphs_entity_embed-single_use-3132549-2.patch",
-      "add openerParameters to ensure media added within embedded paragraphs is associated with the group": "patches/paragraphs_entity_embed-opener_parameters-ck5.patch"
-    },
     "drupal/linked_field": {
       "Generate relative links rather than absolute": "https://www.drupal.org/files/issues/2020-05-22/linked_field-relative-destination-url-3139179-1-D8.patch",
       "Fixes issue with misconfigured layout_builder block": "patches/add-logic-to-resolve-broken-value.patch"


### PR DESCRIPTION
… paragraphs_entity_embed module

Closes https://jira.epa.gov/browse/WEBCMS-311
## Description

The patch could not be applied because it was already merged in to paragraphs_entity_embed 4.0.0 . This merge removes the patch.