### PR TITLE
WEBCMS-312 HTML Editor Insert not working in WYSIWYG

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -178,7 +178,7 @@
         "drupal/ckeditor5_dev": "^1.0",
         "drupal/ckeditor5_fullscreen": "^1.0",
         "drupal/ckeditor_abbreviation": "^5.0",
-        "drupal/ckeditor_html_embed": "^1.0",
+        "drupal/ckeditor_html_embed": "^2.0",
         "drupal/ckeditor_iframe": "^3.0@beta",
         "drupal/cloudfront_cache_path_invalidate": "^4.1",
         "drupal/components": "^3.1",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fcf0352f67791d856ddca042e0bc1ed",
+    "content-hash": "d31a6c752044afbab81e8a9060312f63",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2797,26 +2797,26 @@
         },
         {
             "name": "drupal/ckeditor_html_embed",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/ckeditor_html_embed.git",
-                "reference": "1.0.2"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/ckeditor_html_embed-1.0.2.zip",
-                "reference": "1.0.2",
-                "shasum": "dff1858fcf3bb31f429480c2abbeffa06f833852"
+                "url": "https://ftp.drupal.org/files/projects/ckeditor_html_embed-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "03997fd8ea56457f33a220f3b9b78071c0fc78aa"
             },
             "require": {
-                "drupal/core": "^9.4 || ^10 || ^11"
+                "drupal/core": "^10.5 || ^11.2"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.0.2",
-                    "datestamp": "1726194923",
+                    "version": "2.0.0",
+                    "datestamp": "1780491485",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Closes https://jira.epa.gov/browse/WEBCMS-312

## Description

HTML Editor button in CKEditor was not functioning. Upgrading the module to version 2.0.0 fixed the issue.
