### PR TITLE
Update package-lock.json to close #1909

### DIFF
--- a/services/drupal/web/themes/epa_theme/package-lock.json
+++ b/services/drupal/web/themes/epa_theme/package-lock.json
@@ -16081,9 +16081,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "dependencies": {
         "http-parser-js": ">=0.5.1",
@@ -28509,9 +28509,9 @@
       "dev": true
     },
     "websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "requires": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
build(deps): bump websocket-driver from 0.7.4 to 0.7.5 in /services/drupal/web/themes/epa_theme #1909. Merging this pull request will resolve [Dependabot Alerts](https://github.com/USEPA/webcms/security/dependabot?q=package%3Awebsocket-driver+manifest%3Aservices%2Fdrupal%2Fweb%2Fthemes%2Fepa_theme%2Fpackage-lock.json+has%3Apatch) on websocket-driver including a critical severity alert