### PR TITLE
Enhance CI Prisma Scans and Optimize Docker Builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -504,46 +504,51 @@ build:drupal:stage:
 # These jobs pull images from GitLab registry and scan them using twistcli
 # Only runs on staging branch (stage deployments)
 
+# Shared script anchor for Prisma scan steps — used by all three jobs.
+# PRISMA_TOKEN: the CI Integration token from Prisma Cloud Console:
+#   Compute → Manage → System → (copy the access token)
+# Store it as PRISMA_TOKEN in GitLab CI/CD variables for this project.
+.prisma_scan_steps: &prisma_scan_steps
+  before_script:
+    - |
+      if [ -n "${WEBCMS_SITE_FILTER}" ] && [ "${WEBCMS_SITE}" != "${WEBCMS_SITE_FILTER}" ]; then
+        echo "Skipping scan for site '${WEBCMS_SITE}' - filter is '${WEBCMS_SITE_FILTER}'"
+        exit 0
+      fi
+    - |
+      if [ -z "$PRISMA_TOKEN" ]; then
+        echo "ERROR: PRISMA_TOKEN is not set. Get the token from Prisma Cloud: Compute > Manage > System."
+        exit 1
+      fi
+    - 'curl --progress-bar -L -k --header "Authorization: Bearer $PRISMA_TOKEN" https://prismacloud.epa.gov/api/v1/util/twistcli > twistcli; chmod a+x twistcli;'
+
 Prisma:Drupal:
   stage: Scan
   tags:
-    - twistcli  # Requires runner with Docker and twistcli support
+    - twistcli
   needs:
     - job: "build:drupal:stage"
-      optional: true  # Run even if build skipped (for tagged releases)
+      optional: true
   rules:
-    - if: '$CI_COMMIT_TAG'  # Run on tagged releases
+    - if: '$CI_COMMIT_TAG'
       variables:
-        WEBCMS_IMAGE_TAG: $CI_COMMIT_TAG  # Use tag as image tag
-    - if: '$CI_COMMIT_BRANCH == "staging"'  # Run on staging branch only (stage site)
+        WEBCMS_IMAGE_TAG: $CI_COMMIT_TAG
+    - if: '$CI_COMMIT_BRANCH == "staging"'
   parallel:
     matrix:
-      - WEBCMS_SITE: [stage]  # Scan stage site only (not dev)
+      - WEBCMS_SITE: [stage]
   variables:
-    GIT_STRATEGY: none  # Don't clone repo (only need to pull Docker image)
+    GIT_STRATEGY: none
     WEBCMS_ENVIRONMENT: preproduction
-  before_script:
-    # Skip scan if WEBCMS_SITE_FILTER is set and doesn't match current site
-    - |
-      if [ -n "${WEBCMS_SITE_FILTER}" ] && [ "${WEBCMS_SITE}" != "${WEBCMS_SITE_FILTER}" ]; then
-        echo "Skipping scan for site '${WEBCMS_SITE}' - doesn't match filter '${WEBCMS_SITE_FILTER}'"
-        exit 0
-      fi
+  <<: *prisma_scan_steps
   script:
-    # Validate credentials are set before attempting download/scan
-    - |
-      if [ -z "$PRISMA_CI_USERNAME" ] || [ -z "$PRISMA_CI_PASSWORD" ]; then
-        echo "ERROR: PRISMA_CI_USERNAME or PRISMA_CI_PASSWORD is not set in GitLab CI/CD variables."
-        exit 1
-      fi
-    # Download twistcli using credentials directly (avoids JWT token intermediary issues)
-    - 'curl --progress-bar -L -k --user "$PRISMA_CI_USERNAME:$PRISMA_CI_PASSWORD" https://prismacloud.epa.gov/api/v1/util/twistcli > twistcli; chmod a+x twistcli;'
-    # Login to GitLab container registry to pull the image for scanning
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin $CI_REGISTRY
     - docker pull $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-drupal:$WEBCMS_IMAGE_TAG
-    # Scan image — twistcli outputs findings and a direct link to Prisma Cloud console on success
-    - ./twistcli images scan $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-drupal:$WEBCMS_IMAGE_TAG --address=https://prismacloud.epa.gov --details --user=$PRISMA_CI_USERNAME --password=$PRISMA_CI_PASSWORD
+    - ./twistcli images scan $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-drupal:$WEBCMS_IMAGE_TAG --address=https://prismacloud.epa.gov --details --token=$PRISMA_TOKEN
   allow_failure: true
+
+Prisma:Nginx:
+  stage: Scan
   tags:
     - twistcli
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -558,31 +558,21 @@ Prisma:Nginx:
     - if: '$CI_COMMIT_TAG'
       variables:
         WEBCMS_IMAGE_TAG: $CI_COMMIT_TAG
-    - if: '$CI_COMMIT_BRANCH == "staging"'  # Run on staging branch only (stage site)
+    - if: '$CI_COMMIT_BRANCH == "staging"'
   parallel:
     matrix:
-      - WEBCMS_SITE: [stage]  # Scan stage site only (not dev)
+      - WEBCMS_SITE: [stage]
   variables:
-    GIT_STRATEGY: none  # Don't clone repo (only need to pull Docker image)
+    GIT_STRATEGY: none
     WEBCMS_ENVIRONMENT: preproduction
-  before_script:
-    # Skip scan if WEBCMS_SITE_FILTER is set and doesn't match current site
-    - |
-      if [ -n "${WEBCMS_SITE_FILTER}" ] && [ "${WEBCMS_SITE}" != "${WEBCMS_SITE_FILTER}" ]; then
-        echo "Skipping scan for site '${WEBCMS_SITE}' - doesn't match filter '${WEBCMS_SITE_FILTER}'"
-        exit 0
-      fi
+  <<: *prisma_scan_steps
   script:
-    - |
-      if [ -z "$PRISMA_CI_USERNAME" ] || [ -z "$PRISMA_CI_PASSWORD" ]; then
-        echo "ERROR: PRISMA_CI_USERNAME or PRISMA_CI_PASSWORD is not set in GitLab CI/CD variables."
-        exit 1
-      fi
-    - 'curl --progress-bar -L -k --user "$PRISMA_CI_USERNAME:$PRISMA_CI_PASSWORD" https://prismacloud.epa.gov/api/v1/util/twistcli > twistcli; chmod a+x twistcli;'
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin $CI_REGISTRY
     - docker pull $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-nginx:$WEBCMS_IMAGE_TAG
-    - ./twistcli images scan $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-nginx:$WEBCMS_IMAGE_TAG --address=https://prismacloud.epa.gov --details --user=$PRISMA_CI_USERNAME --password=$PRISMA_CI_PASSWORD
-  allow_failure: true  # Don't block pipeline on scan failures
+    - ./twistcli images scan $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-nginx:$WEBCMS_IMAGE_TAG --address=https://prismacloud.epa.gov --details --token=$PRISMA_TOKEN
+  allow_failure: true
+
+Prisma:Drush:
   stage: Scan
   tags:
     - twistcli
@@ -593,31 +583,19 @@ Prisma:Nginx:
     - if: '$CI_COMMIT_TAG'
       variables:
         WEBCMS_IMAGE_TAG: $CI_COMMIT_TAG
-    - if: '$CI_COMMIT_BRANCH == "staging"'  # Run on staging branch only (stage site)
+    - if: '$CI_COMMIT_BRANCH == "staging"'
   parallel:
     matrix:
-      - WEBCMS_SITE: [stage]  # Scan stage site only (not dev)
+      - WEBCMS_SITE: [stage]
   variables:
-    GIT_STRATEGY: none  # Don't clone repo (only need to pull Docker image)
+    GIT_STRATEGY: none
     WEBCMS_ENVIRONMENT: preproduction
-  before_script:
-    # Skip scan if WEBCMS_SITE_FILTER is set and doesn't match current site
-    - |
-      if [ -n "${WEBCMS_SITE_FILTER}" ] && [ "${WEBCMS_SITE}" != "${WEBCMS_SITE_FILTER}" ]; then
-        echo "Skipping scan for site '${WEBCMS_SITE}' - doesn't match filter '${WEBCMS_SITE_FILTER}'"
-        exit 0
-      fi
+  <<: *prisma_scan_steps
   script:
-    - |
-      if [ -z "$PRISMA_CI_USERNAME" ] || [ -z "$PRISMA_CI_PASSWORD" ]; then
-        echo "ERROR: PRISMA_CI_USERNAME or PRISMA_CI_PASSWORD is not set in GitLab CI/CD variables."
-        exit 1
-      fi
-    - 'curl --progress-bar -L -k --user "$PRISMA_CI_USERNAME:$PRISMA_CI_PASSWORD" https://prismacloud.epa.gov/api/v1/util/twistcli > twistcli; chmod a+x twistcli;'
     - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin $CI_REGISTRY
     - docker pull $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-drush:$WEBCMS_IMAGE_TAG
-    - ./twistcli images scan $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-drush:$WEBCMS_IMAGE_TAG --address=https://prismacloud.epa.gov --details --user=$PRISMA_CI_USERNAME --password=$PRISMA_CI_PASSWORD
-  allow_failure: true  # Don't block pipeline on scan failures
+    - ./twistcli images scan $CI_REGISTRY_IMAGE/webcms-${WEBCMS_ENVIRONMENT}-${WEBCMS_SITE}-drush:$WEBCMS_IMAGE_TAG --address=https://prismacloud.epa.gov --details --token=$PRISMA_TOKEN
+  allow_failure: true
 #region Preproduction AWS Account
 
 # Preproduction AWS Account Jobs

--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -193,15 +193,17 @@ ENV GIT_TAG=${GIT_TAG} GIT_COMMIT=${GIT_COMMIT}
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:8080/ping || exit 1
 
-# Build an nginx container that has the same view into the Drupal filesystem
-# as well as its configuration file.
+# Build an nginx container for serving static assets and proxying PHP requests.
 FROM public.ecr.aws/docker/library/nginx:mainline-alpine AS nginx
 
 # Bump system packages
 RUN apk upgrade
 
-# Copy the Drupal filesystem into this image
-COPY --from=drupal /var/www/html /var/www/html
+# Copy only the web directory from the drupal stage.
+# Nginx serves static assets from web/ and proxies PHP requests to PHP-FPM;
+# vendor/, config/, drush/ etc. are PHP-runtime concerns only the drupal
+# container needs. Scoping this COPY to web/ reduces image size and build time.
+COPY --from=drupal /var/www/html/web /var/www/html/web
 
 # Copy nginx configuration
 COPY status.conf *.map /etc/nginx/conf.d/

--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -142,6 +142,19 @@ RUN set -ex \
 # Create the final Drupal 10 image - build this by specifying "docker build --target drupal"
 FROM base AS drupal
 
+# Install additional certificates early so this layer can be cached
+# independently of application code changes (web, config, drush).
+# The TLS certs and RDS bundle rarely change, so moving them before the
+# frequently-changing COPY operations allows Kaniko to cache this layer.
+COPY tls /usr/share/ca-certificates/extra
+RUN \
+  for cert in $(cd /usr/share/ca-certificates; echo extra/*); do \
+    echo "$cert" >> /etc/ca-certificates.conf; \
+  done \
+  && update-ca-certificates \
+  # Append AWS' RDS certificate bundle to the bundle we verify in settings.php
+  && curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem >> /etc/ssl/cert.pem
+
 # Copy Composer-installed packages
 COPY --from=deps /app/web web
 COPY --from=deps /app/vendor vendor
@@ -161,17 +174,6 @@ COPY load.environment.php ./
 COPY web web
 COPY config config
 COPY drush drush
-
-# Copy additional certificates for use by Drupal and bundle them into the system
-# certificates
-COPY tls /usr/share/ca-certificates/extra
-RUN \
-  for cert in $(cd /usr/share/ca-certificates; echo extra/*); do \
-    echo "$cert" >> /etc/ca-certificates.conf; \
-  done \
-  && update-ca-certificates \
-  # Append AWS' RDS certificate bundle to the bundle we verify in settings.php
-  && curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem >> /etc/ssl/cert.pem
 
 
 # Add build metadata to the image. We expose two optional build args:

--- a/services/drupal/Dockerfile
+++ b/services/drupal/Dockerfile
@@ -281,11 +281,8 @@ RUN set -ex \
     echo "error_reporting=${PHP_ERROR_REPORTING}"; \
   } | tee /usr/local/etc/php/php-cli.ini
 
-# Same as nginx: copy the built Drupal filesystem
-COPY --from=drupal /var/www/html /var/www/html
-
-# Copy additional certificates for use by Drupal and bundle them into the system
-# certificates
+# Install additional certificates early (same pattern as drupal stage) so
+# this layer can be cached independently of the Drupal filesystem copy.
 COPY tls /usr/share/ca-certificates/extra
 RUN \
   for cert in $(cd /usr/share/ca-certificates; echo extra/*); do \
@@ -293,6 +290,10 @@ RUN \
   done \
   && update-ca-certificates \
   && curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem >> /etc/ssl/cert.pem
+
+# Copy the full Drupal filesystem (drush needs vendor/, config/, etc.
+# unlike nginx which only needs web/)
+COPY --from=drupal /var/www/html /var/www/html
 
 # Copy the migration script into /usr/local/bin as a command
 COPY scripts/ecs/drush-migrate.sh /usr/local/bin/drush-migrate


### PR DESCRIPTION
Closes [WEBSUP-2165](https://jira.epa.gov/browse/WEBSUP-2165)




## Description

This pull request introduces significant improvements to both the GitLab CI/CD pipeline for Prisma Cloud image scanning and the Docker image build process for Drupal, Nginx, and Drush containers.

- **Summary of changes:**
    - Refactors the GitLab CI/CD pipeline to introduce a shared YAML anchor for Prisma Cloud image scanning steps. This centralizes common logic for filtering sites, validating credentials, and downloading `twistcli`.
    - Migrates the Prisma Cloud authentication method from username/password (`PRISMA_CI_USERNAME`, `PRISMA_CI_PASSWORD`) to a more secure token-based approach (`PRISMA_TOKEN`) for all Drupal, Nginx, and Drush image scans.
    - Optimizes the Dockerfile builds for Drupal and Drush images by moving the installation of additional certificates (TLS and AWS RDS bundle) to an earlier layer. This improves Docker build caching, as these certificate layers rarely change, making subsequent builds faster.
    - Further optimizes the Nginx Dockerfile by selectively copying only the `web/` directory from the Drupal build stage. This significantly reduces the Nginx image size by excluding PHP-runtime specific directories like `vendor/`, `config/`, and `drush/` which are not required by Nginx.

- **Reasoning / higher-level goal:**
    - The CI/CD changes aim to enhance the security, maintainability, and consistency of Prisma Cloud image scanning across different application components by centralizing common steps and adopting a more secure token-based authentication.
    - The Dockerfile optimizations are geared towards improving build performance through better layer caching and reducing the final image size of the Nginx container, leading to faster deployments and reduced resource consumption.

- **Additional context**
    - The Prisma scan jobs for Nginx and Drush were previously migrated to use these shared steps and token authentication, ensuring a consistent approach across all image types.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Configuration change (content types, fields, permissions, workflow)
- [ ] Theme / front-end change
- [x] CI/CD, infrastructure, or deployment change
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would change existing behavior)

## Target Branch

- [x] `development` (feature/bugfix work)
- [ ] `main` (hotfix only — see [Git Workflow](../docs/GIT_WORKFLOW.md#hotfix-flow))

## Testing & Evidence

Describe how you validated this change. A reviewer should be able to see that the
work was tested before it reached them.

- How it was manually tested:
- Commands run (e.g. `ddev drush deploy -y`, `ddev drush config:status`):

## Configuration & Deployment

- [ ] Configuration was exported (`ddev drush cex`) and committed with the code
- [ ] Module add/remove followed the [Config Sync Workflow](../services/drupal/CONFIG_SYNC_WORKFLOW.md)
- [x] This change requires a full build (Composer/theme/Docker/CI changes) — Docker image rebuilds and CI pipeline validation are necessary.
- [ ] No secrets, credentials, or `.env` files are committed

## Docs

Add any notes that help to document the feature/changes: just a few words and/or
code snippets.

## Ready?

Did you do any of the following? If not, no worries, but if you can it's really
helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter (`ddev composer phpcs`, `ddev gesso lint`) to ensure style guidelines were followed
- [ ] Ran static analysis (`ddev composer phpstan`)
- [ ] Created a demo
- [ ] Read and validated this description and the diff myself