### PR TITLE
Change target branch to development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 updates:
   - package-ecosystem: "composer" # This is the entry for your main composer.json.
     assignees:
@@ -20,3 +20,4 @@ updates:
       - "dependencies"
       - "composer"
       - "automated" 
+    target-branch: "development" # Target development branch instead of default 'main'


### PR DESCRIPTION
## Description

Make Dependabot target the development branch instead: most prolonged work is done in the development branch instead of main, so let's update the .github/dependabot.yml file to target the active branch. This stops Dependabot from creating PRs against main that you can't merge.