### PR TITLE
WEBCMS-320 remove custom patch, it's breaking paragraph modal

### DIFF
--- a/services/drupal/composer.patches.json
+++ b/services/drupal/composer.patches.json
@@ -134,8 +134,7 @@
       "Editing links does not remove possible stale data- attributes": "https://www.drupal.org/files/issues/2021-08-09/linkit_rename-stale-data-attributes_3111578-3.patch"
     },
     "drupal/paragraphs_entity_embed": {
-      "Prevent the reuse of embedded paragraphs": "https://www.drupal.org/files/issues/2020-04-30/paragraphs_entity_embed-single_use-3132549-2.patch",
-      "add openerParameters to ensure media added within embedded paragraphs is associated with the group ckeditor5": "patches/paragraphs_entity_embed-opener_parameters-ckeditor5.patch"
+      "Prevent the reuse of embedded paragraphs": "https://www.drupal.org/files/issues/2020-04-30/paragraphs_entity_embed-single_use-3132549-2.patch"
     },
     "drupal/linked_field": {
       "Generate relative links rather than absolute": "https://www.drupal.org/files/issues/2020-05-22/linked_field-relative-destination-url-3139179-1-D8.patch",


### PR DESCRIPTION
Closes [{LINK TO JIRA ISSUE}](https://jira.epa.gov/browse/WEBCMS-320)

## Description

Revert back to removing the custom patch. Even though the custom patch is successfully applied this time around. It's breaking the paragraph popup. 