### PR TITLE
WEBCMS-270 Fix for revisions page, type error

### DIFF
--- a/services/drupal/web/modules/custom/epa_workflow/epa_workflow.module
+++ b/services/drupal/web/modules/custom/epa_workflow/epa_workflow.module
@@ -256,7 +256,7 @@ function epa_workflow_form_alter(array &$form, FormStateInterface $form_state, $
     $form['#attached']['library'][] = 'epa_workflow/revision_list';
     foreach ($form['node_revisions_table'] as $key => $row) {
       // Add some text to the row if the revision is the published rev.
-      if (is_numeric($key) && in_array('is-published', $row['#attributes']['class'])) {
+      if (is_numeric($key) && $row['#attributes']['class'] !== null && in_array('is-published', $row['#attributes']['class'])) {
         $form['node_revisions_table'][$key]['operations']['current-revision']['#markup'] = "<strong>Currently published revision</strong>";
       }
     }


### PR DESCRIPTION
Closes {LINK TO JIRA ISSUE}

## Description

This is not the same issue as the issue tracked in WEBCMS-270

## Screenshots

This push resolves the following error we see when we go to revisions tab.


<img width="1092" height="683" alt="image" src="https://github.com/user-attachments/assets/8373271b-04b0-4267-8614-ee42887b7fae" />
