### PR TITLE
Update epa_workflow.module to fix warnings

### DIFF
--- a/services/drupal/web/modules/custom/epa_workflow/epa_workflow.module
+++ b/services/drupal/web/modules/custom/epa_workflow/epa_workflow.module
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Site\Settings;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Link;
@@ -252,12 +253,21 @@ function epa_workflow_form_alter(array &$form, FormStateInterface $form_state, $
     _epa_workflow_add_compliance_checkboxes($form);
   }
 
-  if ($form_id == 'revision_overview_form') {
+  if ($form_id === 'revision_overview_form') {
     $form['#attached']['library'][] = 'epa_workflow/revision_list';
-    foreach ($form['node_revisions_table'] as $key => $row) {
-      // Add some text to the row if the revision is the published rev.
-      if (is_numeric($key) && $row['#attributes']['class'] !== null && in_array('is-published', $row['#attributes']['class'])) {
-        $form['node_revisions_table'][$key]['operations']['current-revision']['#markup'] = "<strong>Currently published revision</strong>";
+    
+    // Element::children() ensures we only iterate over the actual row arrays,
+    // safely ignoring render properties like #header or #empty.
+    foreach (Element::children($form['node_revisions_table']) as $key) {
+      $row = $form['node_revisions_table'][$key];
+      
+      // Because we used Element::children(), we are guaranteed that $row is an array.
+      // We can now safely check for attributes and classes.
+      $classes = $row['#attributes']['class'] ?? [];
+      
+      if (is_array($classes) && in_array('is-published', $classes, TRUE)) {
+        // Use t() for all user-facing strings to ensure they can be translated.
+        $form['node_revisions_table'][$key]['operations']['current-revision']['#markup'] = '<strong>' . t('Currently published revision') . '</strong>';
       }
     }
   }


### PR DESCRIPTION
Closes WEBCMS-336

## Description

In Drupal, render arrays like $form['node_revisions_table'] contain two things:

1. Children (Data): The actual table rows, which usually have numeric keys (e.g., 0, 1, 2). These are arrays. 
2. Properties (Metadata): Configuration for the render array, which always start with a hash # (e.g., #header, #empty, #type). 

The property #empty (the text displayed when the table has no rows) is typically a translated string created using t('No revisions available'). In Drupal, t() returns an object of type TranslatableMarkup, not a standard string or array.

In the original code, the loop iterates over everything inside the table. On line 261:
$classes = $row['#attributes']['class'] ?? [];

Attempting to access ['#attributes']['class'] before checking if $key is numeric. When the loop reaches the #empty or #title property, $row is that TranslatableMarkup object.

In older versions of PHP, trying to access an object as an array might have failed silently with a warning. However, PHP 8 is much stricter and immediately throws a fatal error: Cannot use object of type TranslatableMarkup as array.

Instead of manually checking if a key is numeric, the Drupal standard is to use \Drupal\Core\Render\Element::children(). This helper function automatically filters out all properties starting with #, ensuring your loop only touches the actual child arrays (your table rows).