### PR TITLE
Disable gesso service in docker-compose

### DIFF
--- a/services/drupal/.ddev/docker-compose.gesso.yaml
+++ b/services/drupal/.ddev/docker-compose.gesso.yaml
@@ -1,13 +1,13 @@
-services:
-  gesso:
-    container_name: ddev-${DDEV_SITENAME}-gesso
-    build: ./gesso
-    command: "sleep infinity"
-    volumes:
-      - ./../web/themes/epa_theme:/var/www/html/web/themes/epa_theme:cached
-      - ".:/mnt/ddev_config"
-    working_dir: /var/www/html/web/themes/epa_theme
-    networks: [default, ddev_default]
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+#services:
+#  gesso:
+#    container_name: ddev-${DDEV_SITENAME}-gesso
+#    build: ./gesso
+#    command: "sleep infinity"
+#    volumes:
+#      - ./../web/themes/epa_theme:/var/www/html/web/themes/epa_theme:cached
+#      - ".:/mnt/ddev_config"
+#    working_dir: /var/www/html/web/themes/epa_theme
+#    networks: [default, ddev_default]
+#    labels:
+#      com.ddev.site-name: ${DDEV_SITENAME}
+#      com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
Comment out the gesso service configuration in docker-compose. Should have been a part of WEBCMS-330

Closes WEBCMS-330

## Description

Comments out the entire gesso service in services/drupal/.ddev/docker-compose.gesso.yaml