### PR TITLE
bump squizlabs/php_codesniffer from 3.13.5 to 3.13.6 in /services/drupal

### DIFF
--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -24743,16 +24743,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -24818,7 +24818,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/browser-kit",


### PR DESCRIPTION
Closes WEBCMS-338 and PR #1960 

## Description

bump squizlabs/php_codesniffer from 3.13.5 to 3.13.6 in /services/drupal. Note that https://github.com/USEPA/webcms/pull/1960 was based off main, not development, which was already running 3.13.5 (not 3.12.0).
