### PR TITLE
Update .ddev/config.yaml to MySQL 8.4

### DIFF
--- a/services/drupal/.ddev/config.yaml
+++ b/services/drupal/.ddev/config.yaml
@@ -10,7 +10,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
   type: mysql
-  version: '8.0'
+  version: '8.4'
 nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true


### PR DESCRIPTION
May require exporting your DB, deleting it, and then reimporting the data after the DB is rebuilt on 8.4

Closes WEBCMS-345

## Description

MySQL 8.0 and MySQL 8.4 have incompatible underlying data storage formats, starting the new 8.4 container with the old 8.0 data volume will cause the database container to crash. First export your data, destroy the old database volume, and import the data into the new 8.4 volume.

1. Export your current database:

`ddev export-db --file=db-backup-8.0.sql.gz`

2. Update the DDEV configuration. Update .ddev/config.yaml:

```
database:
  type: mysql
  version: '8.4'
```

3. Delete the project volume. Run the delete command with the omit-snapshot flag (-O).

`ddev delete -O`

4. Restart the updated environment:

`ddev start`

5.Import your database:

`ddev import-db --file=db-backup-8.0.sql.gz`