### PR TITLE
WEBCMS-320 remove openerparameters tag that is related to removed cus…

### DIFF
--- a/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
+++ b/services/drupal/web/modules/custom/epa_web_areas/epa_web_areas.module
@@ -329,12 +329,6 @@ function _add_ckeditor5_settings(&$settings, mixed $setting, GroupInterface $gro
       }
     }
 
-    // Add group ID as query parameter for embeddedParagraph plugin.
-    if ($key == 'embeddedParagraph') {
-      $opener_params = $value['openerParameters'];
-      $opener_params .= '&group=' . $group->id();
-      $settings['editor']['formats'][$format]['editorSettings']['config'][$key]['openerParameters'] = $opener_params;
-    }
   }
 }
 


### PR DESCRIPTION
…tom patch

Closes WEBCMS-320

## Description

Resolves the issue where openerParameters variable used by a custom patch is still lingering in  a custom module.