### PR TITLE
Update drupal/core-dev to 10.6.15

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -325,7 +325,7 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
-        "drupal/core-dev": "10.6.12",
+        "drupal/core-dev": "^10.6.15",
         "drupal/devel": "^5.0",
         "drupal/upgrade_status": "^4.3",
         "kint-php/kint": "^3.3",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a585da7631e3d6d1e88240330fa8e756",
+    "content-hash": "9cb65192b180b68d2eaf2de166cf157a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -20546,7 +20546,7 @@
         },
         {
             "name": "drupal/core-dev",
-            "version": "10.6.12",
+            "version": "10.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",
@@ -20596,7 +20596,7 @@
             ],
             "description": "require-dev dependencies from drupal/drupal; use in addition to drupal/core-recommended to run tests from drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-dev/tree/10.6.12"
+                "source": "https://github.com/drupal/core-dev/tree/10.6.15"
             },
             "time": "2026-05-20T15:35:08+00:00"
         },


### PR DESCRIPTION
Closes PR #1976 since dependabot goes too far with its composer.lock changes. Should have done this update in WEBCMS-336