### PR TITLE
Fixes 'epa_revision_automated' field availability

### DIFF
--- a/services/drupal/web/modules/custom/epa_workflow/epa_workflow.module
+++ b/services/drupal/web/modules/custom/epa_workflow/epa_workflow.module
@@ -26,8 +26,7 @@ use Drupal\paragraphs\Entity\Paragraph;
  */
 function epa_workflow_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
-  $config_syncing = \Drupal::isConfigSyncing();
-  if ($entity_type->id() == 'node' && !$config_syncing) {
+  if ($entity_type->id() == 'node') {
     $fields['epa_revision_automated'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Moderation automated'))
       ->setDescription(t('When true current moderation state is automated.'))


### PR DESCRIPTION
Closes [WEBSUP-2174](https://jira.epa.gov/browse/WEBSUP-2174)

## Description

This pull request ensures the consistent availability of the `epa_revision_automated` base field for node entities.

- **Summary of changes**: Removes the conditional `$config_syncing` check from the `epa_workflow_entity_base_field_info` hook.
- **Reasoning / higher-level goal**: Previously, the `epa_revision_automated` field might not have been defined for node entities during configuration synchronization, potentially leading to errors or inconsistent behavior. This change guarantees that the field is always added, improving the robustness and reliability of the EPA Workflow module, especially during deployments and configuration imports.
- **Additional context**: The change prevents scenarios where the field might be unexpectedly absent.
