### PR TITLE
Enhances scheduled publish cron resiliency and ensures image toolkit configuration

### DIFF
--- a/services/drupal/web/modules/custom/epa_core/epa_core.install
+++ b/services/drupal/web/modules/custom/epa_core/epa_core.install
@@ -192,3 +192,18 @@ function epa_core_update_9007() {
 function epa_core_update_9008() {
   \Drupal::database()->truncate('cache_container');
 }
+
+/**
+ * Ensure system.image.toolkit is set to gd.
+ *
+ * On some environments the active system.image config has an empty
+ * "toolkit" value, which causes a PluginNotFoundException ("The \"\"
+ * plugin does not exist") whenever an entity with an image field is
+ * saved, e.g. during the epa_workflow scheduled publish cron run.
+ */
+function epa_core_update_9009() {
+  $config = \Drupal::configFactory()->getEditable('system.image');
+  if (empty($config->get('toolkit'))) {
+    $config->set('toolkit', 'gd')->save();
+  }
+}

--- a/services/drupal/web/modules/custom/epa_workflow/src/EPAScheduledPublishCron.php
+++ b/services/drupal/web/modules/custom/epa_workflow/src/EPAScheduledPublishCron.php
@@ -120,9 +120,22 @@ class EPAScheduledPublishCron extends ScheduledPublishCron {
             $query->$revisionLimiter();
             $entities = $query->execute();
             foreach ($entities as $entityRevision => $entityId) {
-              $entity = $this->entityTypeManager->getStorage($entityType)
-                ->loadRevision($entityRevision);
-              $this->updateEntityField($entity, $scheduledField);
+              try {
+                $entity = $this->entityTypeManager->getStorage($entityType)
+                  ->loadRevision($entityRevision);
+                $this->updateEntityField($entity, $scheduledField);
+              }
+              catch (\Exception $e) {
+                // Log and continue so a single failed save (e.g. a
+                // transient database lock timeout) doesn't prevent other
+                // eligible entities from being processed in this run.
+                $this->logger->get('epa_workflow')->error('Failed to process scheduled transition for @type @id (revision @revision): @message', [
+                  '@type' => $entityType,
+                  '@id' => $entityId,
+                  '@revision' => $entityRevision,
+                  '@message' => $e->getMessage(),
+                ]);
+              }
             }
           }
         }


### PR DESCRIPTION
Closes [WEBSUP-2175](https://jira.epa.gov/browse/WEBSUP-2175)


## Summary of changes

-   A new update hook (`epa_core_update_9009`) to ensure the `system.image` configuration's `toolkit` value is explicitly set to `gd` if it's empty. This prevents `PluginNotFoundException` errors that can occur when image-related entities are saved and the image toolkit is not properly configured.
-   A `try-catch` block now surrounds the processing of individual entities during a scheduled publish run in 'EPAScheduledPublishCron'. This ensures that if a single entity fails to save (e.g., due to a transient database lock, validation error, or other exceptions), the error is logged, and the cron process can continue to attempt publishing other eligible entities without completely halting.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Target Branch

- [x] `development` (feature/bugfix work)

- How it was manually tested:
- Commands run (e.g. `ddev drush deploy -y`, `ddev drush config:status`):
