### PR TITLE
Update scheduled_publish to 4.1.0 (from 3.10)

### DIFF
--- a/services/drupal/composer.json
+++ b/services/drupal/composer.json
@@ -269,7 +269,7 @@
         "drupal/role_theme_switcher": "^1.2",
         "drupal/s3fs": "^3.10",
         "drupal/samlauth": "^3.14",
-        "drupal/scheduled_publish": "^3.9",
+        "drupal/scheduled_publish": "^4.1",
         "drupal/schema_metatag": "^3.0",
         "drupal/search_api": "^1.27",
         "drupal/seckit": "^2.0",

--- a/services/drupal/composer.lock
+++ b/services/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cb65192b180b68d2eaf2de166cf157a",
+    "content-hash": "85f57ac5fa889b67e57da0a83adf311e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8847,26 +8847,30 @@
         },
         {
             "name": "drupal/scheduled_publish",
-            "version": "3.10.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/scheduled_publish.git",
-                "reference": "8.x-3.10"
+                "reference": "4.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/scheduled_publish-8.x-3.10.zip",
-                "reference": "8.x-3.10",
-                "shasum": "fbdccb0e11eebb08cc4e77210b8809fff8836a3d"
+                "url": "https://ftp.drupal.org/files/projects/scheduled_publish-4.1.0.zip",
+                "reference": "4.1.0",
+                "shasum": "05b06ab05f7b2b37271bba33aeb8d97f41e18d87"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10"
+                "drupal/core": "^9.5 || ^10.2 || ^11",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "drush/drush": ">=11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.10",
-                    "datestamp": "1687093838",
+                    "version": "4.1.0",
+                    "datestamp": "1758332277",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8874,7 +8878,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9"
+                        "drush.services.yml": "^11"
                     }
                 }
             },
@@ -8884,24 +8888,32 @@
             ],
             "authors": [
                 {
-                    "name": "lostcarpark",
-                    "homepage": "https://www.drupal.org/user/346773"
+                    "name": "Sascha Hannes (SaschaHannes)",
+                    "homepage": "https://www.drupal.org/u/SaschaHannes",
+                    "role": "Maintainer"
                 },
                 {
-                    "name": "marcoliver",
-                    "homepage": "https://www.drupal.org/user/1529744"
+                    "name": "Peter Majmesku (peter-majmesku)",
+                    "homepage": "https://www.drupal.org/u/peter-majmesku",
+                    "role": "Maintainer"
                 },
                 {
-                    "name": "Peter Majmesku",
-                    "homepage": "https://www.drupal.org/user/786132"
+                    "name": "Sergei Semipiadniy (sergei_semipiadniy)",
+                    "homepage": "https://www.drupal.org/u/sergei_semipiadniy",
+                    "role": "Maintainer"
                 },
                 {
-                    "name": "SaschaHannes",
-                    "homepage": "https://www.drupal.org/user/3536189"
+                    "name": "James Shields (lostcarpark)",
+                    "homepage": "https://www.drupal.org/u/lostcarpark",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "vitaliyb98",
+                    "homepage": "https://www.drupal.org/user/3514011"
                 }
             ],
             "description": "A simple module for scheduled content moderation",
-            "homepage": "https://www.drupal.org/project/scheduled_publish",
+            "homepage": "https://drupal.org/project/scheduled_publish",
             "support": {
                 "source": "https://git.drupalcode.org/project/scheduled_publish"
             }

--- a/services/drupal/web/modules/custom/epa_workflow/src/Plugin/Field/FieldFormatter/EPAScheduledPublishGenericFormatter.php
+++ b/services/drupal/web/modules/custom/epa_workflow/src/Plugin/Field/FieldFormatter/EPAScheduledPublishGenericFormatter.php
@@ -36,7 +36,7 @@ class EPAScheduledPublishGenericFormatter extends ScheduledPublishGenericFormatt
    * {@inheritdoc}
    */
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, LoggerChannelFactoryInterface $logger_channel_factory, EntityTypeManager $entity_type_manager, ModerationInformationInterface $moderation_information) {
-    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings, $logger_channel_factory, $entity_type_manager);
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings, $logger_channel_factory, $entity_type_manager, $moderation_information);
     $this->moderationInformation = $moderation_information;
   }
 


### PR DESCRIPTION
Closes [WEBCMS-347](https://jira.epa.gov/browse/WEBCMS-347)

## Description

Updates drupal/scheduled_publish from 8.x-3.10 to 4.1.0. 

One thing to note: needed to update the `parent::__construct` (line 39) in modules/custom/epa_workflow/src/Plugin/Field/FieldFormatter/EPAScheduledPublishGenericFormatter.php